### PR TITLE
feat: add complete mod_attendancecontrol plugin structure (Moodle 4.5, 2026)

### DIFF
--- a/amd/src/attendance_form.js
+++ b/amd/src/attendance_form.js
@@ -1,0 +1,80 @@
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * AMD module: attendance_form
+ *
+ * Handles the "Mark all as ..." bulk action on the attendance registration
+ * form (attendance.php). When the teacher selects a status from the bulk
+ * selector, all individual student selects are updated to match.
+ *
+ * @module     mod_attendancecontrol/attendance_form
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Initialises the bulk-status behaviour.
+ *
+ * Called by PHP via $PAGE->requires->js_call_amd(...).
+ *
+ * @param {string} formSelector CSS selector for the attendance form.
+ */
+export const init = (formSelector = 'form[data-region="attendance-form"]') => {
+    const form = document.querySelector(formSelector);
+    if (!form) {
+        return;
+    }
+
+    const bulkSelect = form.querySelector('[name="bulk_status"]');
+    if (!bulkSelect) {
+        return;
+    }
+
+    // Apply bulk status to all student selects.
+    const applyBulk = () => {
+        const value = bulkSelect.value;
+        form.querySelectorAll('select[name^="student_status"]').forEach((sel) => {
+            sel.value = value;
+        });
+    };
+
+    bulkSelect.addEventListener('change', applyBulk);
+
+    // Collapse/expand remarks textareas by default.
+    form.querySelectorAll('textarea[name^="student_remarks"]').forEach((ta) => {
+        // Wrap in a collapsible element if not already done by Moodle.
+        const wrapper = ta.closest('.fitem');
+        if (wrapper && !wrapper.dataset.collapsible) {
+            wrapper.dataset.collapsible = 'true';
+            ta.style.display = 'none';
+
+            const toggle = document.createElement('button');
+            toggle.type = 'button';
+            toggle.className = 'btn btn-link btn-sm p-0 ms-1';
+            toggle.textContent = '[+]';
+            toggle.setAttribute('aria-expanded', 'false');
+
+            toggle.addEventListener('click', () => {
+                const expanded = toggle.getAttribute('aria-expanded') === 'true';
+                ta.style.display = expanded ? 'none' : '';
+                toggle.setAttribute('aria-expanded', String(!expanded));
+                toggle.textContent = expanded ? '[+]' : '[−]';
+            });
+
+            wrapper.querySelector('.fitemtitle')?.appendChild(toggle);
+        }
+    });
+};

--- a/amd/src/session_navigation.js
+++ b/amd/src/session_navigation.js
@@ -1,0 +1,57 @@
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * AMD module: session_navigation
+ *
+ * Enhances the teacher's main view (view.php) with client-side week
+ * navigation highlighting. Marks the current-day session row and
+ * provides keyboard accessibility for the navigation buttons.
+ *
+ * @module     mod_attendancecontrol/session_navigation
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Initialises the session navigation enhancements.
+ *
+ * @param {string} region CSS data-region attribute value of the view container.
+ */
+export const init = (region = 'attendancecontrol-view') => {
+    const container = document.querySelector(`[data-region="${region}"]`);
+    if (!container) {
+        return;
+    }
+
+    // Ensure today's rows receive the highlight class if not already set
+    // server-side (belt-and-suspenders approach).
+    const todayRows = container.querySelectorAll('tr.table-info');
+    todayRows.forEach((row) => {
+        row.setAttribute('aria-current', 'date');
+    });
+
+    // Add keyboard navigation between weeks (left/right arrow keys).
+    const prevBtn = container.querySelector('a[href*="week="]');
+    const nextBtn = container.querySelectorAll('a[href*="week="]')[1];
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowLeft' && prevBtn) {
+            prevBtn.click();
+        } else if (e.key === 'ArrowRight' && nextBtn) {
+            nextBtn.click();
+        }
+    });
+};

--- a/attendance.php
+++ b/attendance.php
@@ -1,0 +1,90 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Attendance registration page for a single session.
+ *
+ * Teachers/managers use this page to mark each student as present, late,
+ * justified absence, or unjustified absence for a given session.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+
+$cmid      = required_param('id',        PARAM_INT); // Course-module ID.
+$sessionid = required_param('sessionid', PARAM_INT); // Session ID.
+
+[$course, $cm] = get_course_and_cm_from_cmid($cmid, 'attendancecontrol');
+
+require_login($course, true, $cm);
+
+$context  = context_module::instance($cm->id);
+$instance = $DB->get_record('attendancecontrol', ['id' => $cm->instance], '*', MUST_EXIST);
+$session  = $DB->get_record('attendancecontrol_session', ['id' => $sessionid, 'attendancecontrolid' => $instance->id], '*', MUST_EXIST);
+
+require_capability('mod/attendancecontrol:recordattendance', $context);
+
+$PAGE->set_url('/mod/attendancecontrol/attendance.php', ['id' => $cmid, 'sessionid' => $sessionid]);
+$PAGE->set_title(get_string('recordattendance', 'mod_attendancecontrol'));
+$PAGE->set_heading(format_string($course->fullname));
+$PAGE->set_context($context);
+
+$form = new \mod_attendancecontrol\form\attendance_form(null, [
+    'instance' => $instance,
+    'session'  => $session,
+    'cm'       => $cm,
+    'context'  => $context,
+]);
+
+if ($form->is_cancelled()) {
+    redirect(new moodle_url('/mod/attendancecontrol/view.php', ['id' => $cmid]));
+}
+
+if ($data = $form->get_data()) {
+    // Persist records for each student in the group.
+    $manager = new \mod_attendancecontrol\local\session_manager($instance);
+    $manager->save_attendance_records($session, $data);
+
+    // Fire event.
+    $event = \mod_attendancecontrol\event\attendance_recorded::create([
+        'objectid' => $session->id,
+        'context'  => $context,
+        'other'    => ['sessionid' => $session->id],
+    ]);
+    $event->trigger();
+
+    redirect(
+        new moodle_url('/mod/attendancecontrol/view.php', ['id' => $cmid]),
+        get_string('attendancesaved', 'mod_attendancecontrol'),
+        null,
+        \core\output\notification::NOTIFY_SUCCESS
+    );
+}
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading(
+    get_string('sessionheading', 'mod_attendancecontrol',
+        userdate($session->session_date) . ' — ' . $session->start_time . ' a ' . $session->end_time
+    )
+);
+
+$form->display();
+
+echo $OUTPUT->footer();

--- a/backup/moodle2/backup_attendancecontrol_activity_task.class.php
+++ b/backup/moodle2/backup_attendancecontrol_activity_task.class.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Backup task for mod_attendancecontrol.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/mod/attendancecontrol/backup/moodle2/backup_attendancecontrol_stepslib.php');
+
+/**
+ * Provides the steps required to backup one attendancecontrol activity.
+ */
+class backup_attendancecontrol_activity_task extends backup_activity_task {
+
+    /**
+     * No specific settings for this activity.
+     */
+    protected function define_my_settings(): void {
+        // Nothing to do.
+    }
+
+    /**
+     * Registers the structure backup step.
+     */
+    protected function define_my_steps(): void {
+        $this->add_step(new backup_attendancecontrol_activity_structure_step(
+            'attendancecontrol_structure',
+            'attendancecontrol.xml'
+        ));
+    }
+
+    /**
+     * Encodes content links for rewriting on restore.
+     *
+     * @param  string $content
+     * @return string
+     */
+    public static function encode_content_links(string $content): string {
+        global $CFG;
+
+        $base = preg_quote($CFG->wwwroot, '/');
+
+        // view.php.
+        $search  = "/({$base}\/mod\/attendancecontrol\/view\.php\?id=)([0-9]+)/";
+        $content = preg_replace($search, '$@ATTENDANCECONTROLVIEWBYID*$2@$', $content);
+
+        return $content;
+    }
+}

--- a/backup/moodle2/backup_attendancecontrol_stepslib.php
+++ b/backup/moodle2/backup_attendancecontrol_stepslib.php
@@ -1,0 +1,107 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Backup step definitions for mod_attendancecontrol.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Defines the structure step for backing up attendancecontrol data.
+ */
+class backup_attendancecontrol_activity_structure_step extends backup_activity_structure_step {
+
+    /**
+     * Defines the backup structure tree.
+     *
+     * @return backup_nested_element
+     */
+    protected function define_structure(): backup_nested_element {
+        $userinfo = $this->get_setting_value('userinfo');
+
+        // Root element (instance).
+        $attendancecontrol = new backup_nested_element(
+            'attendancecontrol',
+            ['id'],
+            [
+                'name', 'intro', 'introformat', 'groupid',
+                'total_hours', 'course_start_date', 'course_end_date',
+                'max_unjustified_absence_pct',
+                'delay_to_unjustified_ratio',
+                'justified_to_unjustified_ratio',
+                'timecreated', 'timemodified',
+            ]
+        );
+
+        // Schedule slots.
+        $schedule = new backup_nested_element(
+            'schedule',
+            ['id'],
+            ['day_of_week', 'start_time', 'end_time']
+        );
+
+        // Holidays.
+        $holidays = new backup_nested_element(
+            'holiday',
+            ['id'],
+            ['holiday_date', 'description']
+        );
+
+        // Sessions.
+        $sessions = new backup_nested_element(
+            'session',
+            ['id'],
+            [
+                'session_date', 'start_time', 'end_time',
+                'duration_hours', 'status', 'timecreated', 'timemodified',
+            ]
+        );
+
+        // Attendance records (user data – only if userinfo is enabled).
+        $records = new backup_nested_element(
+            'record',
+            ['id'],
+            ['userid', 'status', 'remarks', 'recorded_by', 'timecreated', 'timemodified']
+        );
+
+        // Build tree.
+        $attendancecontrol->add_child($schedule);
+        $attendancecontrol->add_child($holidays);
+        $attendancecontrol->add_child($sessions);
+        $sessions->add_child($records);
+
+        // Set data sources.
+        $attendancecontrol->set_source_table('attendancecontrol', ['id' => backup::VAR_ACTIVITYID]);
+        $schedule->set_source_table('attendancecontrol_schedule', ['attendancecontrolid' => backup::VAR_PARENTID]);
+        $holidays->set_source_table('attendancecontrol_holiday',  ['attendancecontrolid' => backup::VAR_PARENTID]);
+        $sessions->set_source_table('attendancecontrol_session',  ['attendancecontrolid' => backup::VAR_PARENTID]);
+
+        if ($userinfo) {
+            $records->set_source_table('attendancecontrol_record', ['sessionid' => backup::VAR_PARENTID]);
+        }
+
+        // Annotate IDs that reference other tables.
+        $attendancecontrol->annotate_ids('group', 'groupid');
+        $records->annotate_ids('user', 'userid');
+        $records->annotate_ids('user', 'recorded_by');
+
+        // Return the root.
+        return $this->prepare_activity_structure($attendancecontrol);
+    }
+}

--- a/backup/moodle2/restore_attendancecontrol_activity_task.class.php
+++ b/backup/moodle2/restore_attendancecontrol_activity_task.class.php
@@ -1,0 +1,94 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Restore task for mod_attendancecontrol.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/mod/attendancecontrol/backup/moodle2/restore_attendancecontrol_stepslib.php');
+
+/**
+ * Provides the steps required to restore one attendancecontrol activity.
+ */
+class restore_attendancecontrol_activity_task extends restore_activity_task {
+
+    /**
+     * No specific settings.
+     */
+    protected function define_my_settings(): void {
+        // Nothing to do.
+    }
+
+    /**
+     * Registers the structure restore step.
+     */
+    protected function define_my_steps(): void {
+        $this->add_step(new restore_attendancecontrol_activity_structure_step(
+            'attendancecontrol_structure',
+            'attendancecontrol.xml'
+        ));
+    }
+
+    /**
+     * Defines the contents_conditions for file restoration.
+     *
+     * @return array
+     */
+    public static function define_decode_contents(): array {
+        return [
+            new restore_decode_content('attendancecontrol', ['intro'], 'attendancecontrol'),
+        ];
+    }
+
+    /**
+     * Defines the link rewrites performed during restore.
+     *
+     * @return array
+     */
+    public static function define_decode_rules(): array {
+        return [
+            new restore_decode_rule(
+                'ATTENDANCECONTROLVIEWBYID',
+                '/mod/attendancecontrol/view.php?id=$1',
+                'course_module'
+            ),
+        ];
+    }
+
+    /**
+     * No log entries to restore.
+     *
+     * @return array
+     */
+    public static function define_restore_log_rules(): array {
+        return [];
+    }
+
+    /**
+     * No course-level log entries.
+     *
+     * @return array
+     */
+    public static function define_restore_log_rules_for_course(): array {
+        return [];
+    }
+}

--- a/backup/moodle2/restore_attendancecontrol_stepslib.php
+++ b/backup/moodle2/restore_attendancecontrol_stepslib.php
@@ -1,0 +1,138 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Restore step definitions for mod_attendancecontrol.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Defines the structure step for restoring attendancecontrol data.
+ */
+class restore_attendancecontrol_activity_structure_step extends restore_activity_structure_step {
+
+    /**
+     * Defines the XML paths and DB targets.
+     *
+     * @return array
+     */
+    protected function define_structure(): array {
+        $paths   = [];
+        $userinfo = $this->get_setting_value('userinfo');
+
+        $paths[] = new restore_path_element('attendancecontrol',        '/activity/attendancecontrol');
+        $paths[] = new restore_path_element('attendancecontrol_schedule', '/activity/attendancecontrol/schedule');
+        $paths[] = new restore_path_element('attendancecontrol_holiday',  '/activity/attendancecontrol/holiday');
+        $paths[] = new restore_path_element('attendancecontrol_session',  '/activity/attendancecontrol/session');
+
+        if ($userinfo) {
+            $paths[] = new restore_path_element(
+                'attendancecontrol_record',
+                '/activity/attendancecontrol/session/record'
+            );
+        }
+
+        return $this->prepare_activity_structure($paths);
+    }
+
+    /**
+     * Processes the main instance record.
+     *
+     * @param array|object $data
+     */
+    protected function process_attendancecontrol($data): void {
+        global $DB;
+
+        $data             = (object) $data;
+        $data->course     = $this->get_courseid();
+        $data->timecreated  = time();
+        $data->timemodified = time();
+
+        $newitemid = $DB->insert_record('attendancecontrol', $data);
+        $this->apply_activity_instance($newitemid);
+    }
+
+    /**
+     * Processes a schedule slot.
+     *
+     * @param array|object $data
+     */
+    protected function process_attendancecontrol_schedule($data): void {
+        global $DB;
+
+        $data = (object) $data;
+        $data->attendancecontrolid = $this->get_new_parentid('attendancecontrol');
+        $DB->insert_record('attendancecontrol_schedule', $data);
+    }
+
+    /**
+     * Processes a holiday record.
+     *
+     * @param array|object $data
+     */
+    protected function process_attendancecontrol_holiday($data): void {
+        global $DB;
+
+        $data = (object) $data;
+        $data->attendancecontrolid = $this->get_new_parentid('attendancecontrol');
+        $DB->insert_record('attendancecontrol_holiday', $data);
+    }
+
+    /**
+     * Processes a session record.
+     *
+     * @param array|object $data
+     */
+    protected function process_attendancecontrol_session($data): void {
+        global $DB;
+
+        $data = (object) $data;
+        $data->attendancecontrolid = $this->get_new_parentid('attendancecontrol');
+        $data->timecreated         = isset($data->timecreated)  ? $data->timecreated  : time();
+        $data->timemodified        = isset($data->timemodified) ? $data->timemodified : time();
+
+        $newitemid = $DB->insert_record('attendancecontrol_session', $data);
+        $this->set_mapping('attendancecontrol_session', $data->id, $newitemid);
+    }
+
+    /**
+     * Processes an attendance record (userinfo only).
+     *
+     * @param array|object $data
+     */
+    protected function process_attendancecontrol_record($data): void {
+        global $DB;
+
+        $data             = (object) $data;
+        $data->sessionid  = $this->get_new_parentid('attendancecontrol_session');
+        $data->userid     = $this->get_mappingid('user', $data->userid);
+        $data->recorded_by = $this->get_mappingid('user', $data->recorded_by);
+        $data->timecreated  = isset($data->timecreated)  ? $data->timecreated  : time();
+        $data->timemodified = isset($data->timemodified) ? $data->timemodified : time();
+
+        $DB->insert_record('attendancecontrol_record', $data);
+    }
+
+    /**
+     * Post-execution tasks after all data has been restored.
+     */
+    protected function after_execute(): void {
+        $this->add_related_files('mod_attendancecontrol', 'intro', null);
+    }
+}

--- a/classes/event/attendance_recorded.php
+++ b/classes/event/attendance_recorded.php
@@ -1,0 +1,74 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Event fired when a teacher records/updates attendance for a session.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol\event;
+
+/**
+ * Attendance recorded event.
+ *
+ * Triggered after a teacher successfully saves attendance for a session.
+ */
+class attendance_recorded extends \core\event\base {
+
+    /**
+     * Initialises the event properties.
+     */
+    protected function init(): void {
+        $this->data['crud']           = 'u'; // Update (also covers create on first save).
+        $this->data['edulevel']       = self::LEVEL_TEACHING;
+        $this->data['objecttable']    = 'attendancecontrol_session';
+    }
+
+    /**
+     * Returns the event name shown in the log report.
+     *
+     * @return string
+     */
+    public static function get_name(): string {
+        return get_string('eventattendancerecorded', 'mod_attendancecontrol');
+    }
+
+    /**
+     * Returns a human-readable description of the event.
+     *
+     * @return string
+     */
+    public function get_description(): string {
+        return "The user with id '{$this->userid}' recorded attendance for session id " .
+               "'{$this->objectid}' in the attendancecontrol instance " .
+               "with id '{$this->other['sessionid']}'.";
+    }
+
+    /**
+     * Returns the URL of the relevant page.
+     *
+     * @return \moodle_url
+     */
+    public function get_url(): \moodle_url {
+        return new \moodle_url('/mod/attendancecontrol/attendance.php', [
+            'id'        => $this->contextinstanceid,
+            'sessionid' => $this->objectid,
+        ]);
+    }
+}

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -1,0 +1,42 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Event fired when the attendance activity main page is viewed.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol\event;
+
+/**
+ * Course module viewed event.
+ *
+ * Extends the Moodle core base event for "course module viewed" so that
+ * completion tracking and the standard log report work out of the box.
+ */
+class course_module_viewed extends \core\event\course_module_viewed {
+
+    /**
+     * Initialises the event properties.
+     */
+    protected function init(): void {
+        $this->data['objecttable'] = 'attendancecontrol';
+        parent::init();
+    }
+}

--- a/classes/event/session_created.php
+++ b/classes/event/session_created.php
@@ -1,0 +1,71 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Event fired when a session is automatically generated.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol\event;
+
+/**
+ * Session created event.
+ *
+ * Logged whenever the session_manager generates a new session record.
+ */
+class session_created extends \core\event\base {
+
+    /**
+     * Initialises the event properties.
+     */
+    protected function init(): void {
+        $this->data['crud']        = 'c';
+        $this->data['edulevel']    = self::LEVEL_TEACHING;
+        $this->data['objecttable'] = 'attendancecontrol_session';
+    }
+
+    /**
+     * Returns the event name.
+     *
+     * @return string
+     */
+    public static function get_name(): string {
+        return get_string('eventsessioncreated', 'mod_attendancecontrol');
+    }
+
+    /**
+     * Returns a human-readable event description.
+     *
+     * @return string
+     */
+    public function get_description(): string {
+        return "The user with id '{$this->userid}' created a session with id '{$this->objectid}'.";
+    }
+
+    /**
+     * Returns the URL of the activity.
+     *
+     * @return \moodle_url
+     */
+    public function get_url(): \moodle_url {
+        return new \moodle_url('/mod/attendancecontrol/view.php', [
+            'id' => $this->contextinstanceid,
+        ]);
+    }
+}

--- a/classes/form/attendance_form.php
+++ b/classes/form/attendance_form.php
@@ -1,0 +1,126 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Attendance registration form.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol\form;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($GLOBALS['CFG']->libdir . '/formslib.php');
+
+/**
+ * Form for recording attendance for a single session.
+ *
+ * Custom data expected:
+ *   - instance  \stdClass  Plugin instance record.
+ *   - session   \stdClass  Session record.
+ *   - cm        \cm_info   Course module info.
+ *   - context   \context_module
+ */
+class attendance_form extends \moodleform {
+
+    /**
+     * Defines form elements – one row per group member.
+     */
+    public function definition(): void {
+        $mform    = $this->_form;
+        $instance = $this->_customdata['instance'];
+        $session  = $this->_customdata['session'];
+        $cm       = $this->_customdata['cm'];
+
+        $mform->addElement('hidden', 'id',        $cm->id);
+        $mform->addElement('hidden', 'sessionid', $session->id);
+        $mform->setType('id',        PARAM_INT);
+        $mform->setType('sessionid', PARAM_INT);
+
+        // "Mark all as" bulk action.
+        $bulkoptions = [
+            1 => get_string('statuspresent',     'mod_attendancecontrol'),
+            2 => get_string('statuslate',        'mod_attendancecontrol'),
+            3 => get_string('statusjustified',   'mod_attendancecontrol'),
+            4 => get_string('statusunjustified', 'mod_attendancecontrol'),
+        ];
+        $mform->addElement('select', 'bulk_status', get_string('markallpresent', 'mod_attendancecontrol'), $bulkoptions);
+        $mform->setDefault('bulk_status', 1);
+
+        // Per-student rows.
+        $students = groups_get_members($instance->groupid, 'u.id, u.firstname, u.lastname, u.middlename');
+        uasort($students, static fn($a, $b) => strcmp($a->lastname, $b->lastname));
+
+        $statusoptions = [
+            1 => get_string('statuspresent',     'mod_attendancecontrol'),
+            2 => get_string('statuslate',        'mod_attendancecontrol'),
+            3 => get_string('statusjustified',   'mod_attendancecontrol'),
+            4 => get_string('statusunjustified', 'mod_attendancecontrol'),
+        ];
+
+        foreach ($students as $student) {
+            $uid = $student->id;
+
+            $mform->addElement('header', "student_hdr_{$uid}", fullname($student));
+
+            $mform->addElement(
+                'select',
+                "student_status[{$uid}]",
+                get_string('sessionstatus', 'mod_attendancecontrol'),
+                $statusoptions
+            );
+            $mform->setType("student_status[{$uid}]", PARAM_INT);
+            $mform->setDefault("student_status[{$uid}]", 1);
+
+            $mform->addElement(
+                'textarea',
+                "student_remarks[{$uid}]",
+                get_string('remarks', 'mod_attendancecontrol'),
+                ['rows' => 2, 'cols' => 40]
+            );
+            $mform->setType("student_remarks[{$uid}]", PARAM_TEXT);
+        }
+
+        // Load existing records if already registered.
+        $this->load_existing_records($session);
+
+        $this->add_action_buttons(true, get_string('saveattendance', 'mod_attendancecontrol'));
+    }
+
+    /**
+     * Pre-fills status/remarks from previously saved records.
+     *
+     * @param \stdClass $session
+     */
+    protected function load_existing_records(\stdClass $session): void {
+        global $DB;
+
+        $records = $DB->get_records('attendancecontrol_record', ['sessionid' => $session->id]);
+
+        $currentdata = [];
+        foreach ($records as $rec) {
+            $currentdata["student_status[{$rec->userid}]"]  = $rec->status;
+            $currentdata["student_remarks[{$rec->userid}]"] = $rec->remarks;
+        }
+
+        if ($currentdata) {
+            $this->set_data($currentdata);
+        }
+    }
+}

--- a/classes/local/attendance_calculator.php
+++ b/classes/local/attendance_calculator.php
@@ -1,0 +1,253 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Attendance percentage calculation logic.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol\local;
+
+/**
+ * Computes attendance percentages and produces summary/detail data structures.
+ *
+ * Status codes:
+ *   0 = unregistered (no penalty)
+ *   1 = present      (no penalty)
+ *   2 = late         (duration_hours × delay_to_unjustified_ratio)
+ *   3 = justified    (duration_hours × justified_to_unjustified_ratio)
+ *   4 = unjustified  (duration_hours × 1.0)
+ */
+class attendance_calculator {
+
+    /** @var \stdClass Plugin instance record. */
+    protected \stdClass $instance;
+
+    /**
+     * Constructor.
+     *
+     * @param \stdClass $instance  Row from the attendancecontrol table.
+     */
+    public function __construct(\stdClass $instance) {
+        $this->instance = $instance;
+    }
+
+    // -----------------------------------------------------------------------
+    // Public API.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns one summary row per student in the configured group.
+     *
+     * Each element has:
+     *   - student       \stdClass  Moodle user object (id, firstname, lastname).
+     *   - presences     int
+     *   - lates         int
+     *   - justified     int
+     *   - unjustified   int
+     *   - equiv_hours   float      Equivalent absence hours.
+     *   - pct           float      Attendance percentage (0–100).
+     *   - below_threshold bool     True if pct < threshold.
+     *
+     * @return array
+     */
+    public function get_group_summary(): array {
+        global $DB;
+
+        $students = groups_get_members($this->instance->groupid, 'u.id, u.firstname, u.lastname');
+
+        $result = [];
+        foreach ($students as $student) {
+            $result[] = $this->build_student_summary($student);
+        }
+
+        // Sort alphabetically by lastname, firstname.
+        usort($result, static fn($a, $b) =>
+            strcmp($a['student']->lastname . $a['student']->firstname,
+                   $b['student']->lastname . $b['student']->firstname)
+        );
+
+        return $result;
+    }
+
+    /**
+     * Returns per-session detail for a single student.
+     *
+     * Each element has:
+     *   - session   \stdClass  Session record (id, session_date, start_time, end_time, duration_hours, status).
+     *   - record    \stdClass|null  Attendance record (status, remarks) or null.
+     *
+     * @param  int   $userid
+     * @return array
+     */
+    public function get_student_detail(int $userid): array {
+        global $DB;
+
+        $sessions = $DB->get_records(
+            'attendancecontrol_session',
+            ['attendancecontrolid' => $this->instance->id],
+            'session_date ASC, start_time ASC'
+        );
+
+        $result = [];
+        foreach ($sessions as $session) {
+            $record = $DB->get_record('attendancecontrol_record', [
+                'sessionid' => $session->id,
+                'userid'    => $userid,
+            ]) ?: null;
+
+            $result[] = [
+                'session' => $session,
+                'record'  => $record,
+            ];
+        }
+
+        return $result;
+    }
+
+    // -----------------------------------------------------------------------
+    // Core calculation.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Computes the equivalent absence hours for a student.
+     *
+     * @param  int    $userid
+     * @return float
+     */
+    public function compute_equivalent_absence_hours(int $userid): float {
+        global $DB;
+
+        $sql = '
+            SELECT r.status, s.duration_hours
+              FROM {attendancecontrol_record} r
+              JOIN {attendancecontrol_session} s ON s.id = r.sessionid
+             WHERE r.userid = :userid
+               AND s.attendancecontrolid = :instanceid
+        ';
+
+        $records = $DB->get_records_sql($sql, [
+            'userid'     => $userid,
+            'instanceid' => $this->instance->id,
+        ]);
+
+        $equiv = 0.0;
+        foreach ($records as $rec) {
+            $equiv += $this->status_to_equiv_hours((int) $rec->status, (int) $rec->duration_hours);
+        }
+
+        return $equiv;
+    }
+
+    /**
+     * Computes the attendance percentage for a student.
+     *
+     *   pct = 100 − (equiv_hours / total_hours × 100)
+     *
+     * @param  int    $userid
+     * @return float  Clamped to [0, 100].
+     */
+    public function compute_attendance_pct(int $userid): float {
+        $total = (int) $this->instance->total_hours;
+
+        if ($total <= 0) {
+            return 100.0;
+        }
+
+        $equiv = $this->compute_equivalent_absence_hours($userid);
+        $pct   = 100.0 - ($equiv / $total * 100.0);
+
+        return max(0.0, min(100.0, $pct));
+    }
+
+    /**
+     * Returns the alert threshold (minimum required attendance percentage).
+     *
+     *   threshold = 100 − max_unjustified_absence_pct
+     *
+     * @return float
+     */
+    public function get_threshold(): float {
+        return 100.0 - (float) $this->instance->max_unjustified_absence_pct;
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Maps an attendance status to its equivalent absence hours.
+     *
+     * @param  int   $status
+     * @param  int   $duration  Session duration in hours.
+     * @return float
+     */
+    protected function status_to_equiv_hours(int $status, int $duration): float {
+        return match ($status) {
+            2 => $duration * (float) $this->instance->delay_to_unjustified_ratio,
+            3 => $duration * (float) $this->instance->justified_to_unjustified_ratio,
+            4 => (float) $duration,
+            default => 0.0,
+        };
+    }
+
+    /**
+     * Builds a summary row for a single student.
+     *
+     * @param  \stdClass $student
+     * @return array
+     */
+    protected function build_student_summary(\stdClass $student): array {
+        global $DB;
+
+        $sql = '
+            SELECT r.status, COUNT(*) AS cnt, SUM(s.duration_hours) AS total_dur
+              FROM {attendancecontrol_record} r
+              JOIN {attendancecontrol_session} s ON s.id = r.sessionid
+             WHERE r.userid = :userid
+               AND s.attendancecontrolid = :instanceid
+          GROUP BY r.status
+        ';
+
+        $rows = $DB->get_records_sql($sql, [
+            'userid'     => $student->id,
+            'instanceid' => $this->instance->id,
+        ]);
+
+        $counts = [1 => 0, 2 => 0, 3 => 0, 4 => 0];
+        foreach ($rows as $row) {
+            $counts[(int) $row->status] = (int) $row->cnt;
+        }
+
+        $equiv     = $this->compute_equivalent_absence_hours($student->id);
+        $pct       = $this->compute_attendance_pct($student->id);
+        $threshold = $this->get_threshold();
+
+        return [
+            'student'          => $student,
+            'presences'        => $counts[1],
+            'lates'            => $counts[2],
+            'justified'        => $counts[3],
+            'unjustified'      => $counts[4],
+            'equiv_hours'      => round($equiv, 2),
+            'pct'              => round($pct, 2),
+            'below_threshold'  => $pct < $threshold,
+        ];
+    }
+}

--- a/classes/local/export_manager.php
+++ b/classes/local/export_manager.php
@@ -1,0 +1,202 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Excel export logic for mod_attendancecontrol.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol\local;
+
+/**
+ * Builds and streams a three-sheet Excel workbook to the browser.
+ *
+ * Requires Moodle's built-in MoodleExcelWorkbook (lib/excellib.class.php).
+ */
+class export_manager {
+
+    /** @var \stdClass Plugin instance record. */
+    protected \stdClass $instance;
+
+    /**
+     * Constructor.
+     *
+     * @param \stdClass $instance  Row from the attendancecontrol table.
+     */
+    public function __construct(\stdClass $instance) {
+        $this->instance = $instance;
+    }
+
+    /**
+     * Streams the Excel file to the browser and exits.
+     */
+    public function send_excel(): void {
+        global $CFG;
+
+        require_once($CFG->libdir . '/excellib.class.php');
+
+        $calculator = new attendance_calculator($this->instance);
+        $summary    = $calculator->get_group_summary();
+
+        $filename = clean_filename(
+            get_string('modulename', 'mod_attendancecontrol') . '_' .
+            userdate($this->instance->course_start_date, '%Y%m%d') . '.xls'
+        );
+
+        $workbook = new \MoodleExcelWorkbook('-');
+        $workbook->send($filename);
+
+        $this->build_summary_sheet($workbook, $summary);
+        $this->build_detail_sheet($workbook, $summary);
+        $this->build_config_sheet($workbook);
+
+        $workbook->close();
+        exit;
+    }
+
+    // -----------------------------------------------------------------------
+    // Sheet builders.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Sheet 1 – One row per student with aggregated counts.
+     *
+     * @param \MoodleExcelWorkbook $wb
+     * @param array                $summary
+     */
+    protected function build_summary_sheet(\MoodleExcelWorkbook $wb, array $summary): void {
+        $sheet = $wb->add_worksheet(get_string('excel_sheet_summary', 'mod_attendancecontrol'));
+
+        $headers = [
+            get_string('excel_col_student',    'mod_attendancecontrol'),
+            get_string('presences',            'mod_attendancecontrol'),
+            get_string('lates',                'mod_attendancecontrol'),
+            get_string('justifiedabsences',    'mod_attendancecontrol'),
+            get_string('unjustifiedabsences',  'mod_attendancecontrol'),
+            get_string('excel_col_equivhours', 'mod_attendancecontrol'),
+            get_string('excel_col_pct',        'mod_attendancecontrol'),
+        ];
+
+        foreach ($headers as $col => $h) {
+            $sheet->write_string(0, $col, $h);
+        }
+
+        foreach ($summary as $row => $data) {
+            $r = $row + 1;
+            $sheet->write_string($r, 0, fullname($data['student']));
+            $sheet->write_number($r, 1, $data['presences']);
+            $sheet->write_number($r, 2, $data['lates']);
+            $sheet->write_number($r, 3, $data['justified']);
+            $sheet->write_number($r, 4, $data['unjustified']);
+            $sheet->write_number($r, 5, $data['equiv_hours']);
+            $sheet->write_number($r, 6, $data['pct']);
+        }
+    }
+
+    /**
+     * Sheet 2 – One row per student × session.
+     *
+     * @param \MoodleExcelWorkbook $wb
+     * @param array                $summary
+     */
+    protected function build_detail_sheet(\MoodleExcelWorkbook $wb, array $summary): void {
+        global $DB;
+
+        $sheet = $wb->add_worksheet(get_string('excel_sheet_detail', 'mod_attendancecontrol'));
+
+        $headers = [
+            get_string('excel_col_student',  'mod_attendancecontrol'),
+            get_string('excel_col_date',     'mod_attendancecontrol'),
+            get_string('excel_col_schedule', 'mod_attendancecontrol'),
+            get_string('excel_col_duration', 'mod_attendancecontrol'),
+            get_string('excel_col_status',   'mod_attendancecontrol'),
+            get_string('excel_col_remarks',  'mod_attendancecontrol'),
+        ];
+
+        foreach ($headers as $col => $h) {
+            $sheet->write_string(0, $col, $h);
+        }
+
+        $row = 1;
+        $calculator = new attendance_calculator($this->instance);
+
+        foreach ($summary as $data) {
+            $detail = $calculator->get_student_detail((int) $data['student']->id);
+            foreach ($detail as $item) {
+                $statuslabel = $this->status_label((int) ($item['record']->status ?? 0));
+                $sheet->write_string($row, 0, fullname($data['student']));
+                $sheet->write_string($row, 1, userdate($item['session']->session_date, get_string('strftimedatefullshort')));
+                $sheet->write_string($row, 2, $item['session']->start_time . '-' . $item['session']->end_time);
+                $sheet->write_number($row, 3, $item['session']->duration_hours);
+                $sheet->write_string($row, 4, $statuslabel);
+                $sheet->write_string($row, 5, $item['record']->remarks ?? '');
+                $row++;
+            }
+        }
+    }
+
+    /**
+     * Sheet 3 – Configuration parameters.
+     *
+     * @param \MoodleExcelWorkbook $wb
+     */
+    protected function build_config_sheet(\MoodleExcelWorkbook $wb): void {
+        global $DB;
+
+        $sheet = $wb->add_worksheet(get_string('excel_sheet_config', 'mod_attendancecontrol'));
+        $sheet->write_string(0, 0, get_string('excel_param_subject',        'mod_attendancecontrol'));
+        $sheet->write_string(0, 1, format_string($this->instance->name));
+
+        $group = $DB->get_record('groups', ['id' => $this->instance->groupid], 'name');
+        $sheet->write_string(1, 0, get_string('excel_param_group',          'mod_attendancecontrol'));
+        $sheet->write_string(1, 1, $group ? format_string($group->name) : '');
+
+        $sheet->write_string(2, 0, get_string('excel_param_totalhours',     'mod_attendancecontrol'));
+        $sheet->write_number(2, 1, $this->instance->total_hours);
+
+        $sheet->write_string(3, 0, get_string('excel_param_delayratio',     'mod_attendancecontrol'));
+        $sheet->write_number(3, 1, $this->instance->delay_to_unjustified_ratio);
+
+        $sheet->write_string(4, 0, get_string('excel_param_justifiedratio', 'mod_attendancecontrol'));
+        $sheet->write_number(4, 1, $this->instance->justified_to_unjustified_ratio);
+
+        $sheet->write_string(5, 0, get_string('excel_param_maxpct',         'mod_attendancecontrol'));
+        $sheet->write_number(5, 1, $this->instance->max_unjustified_absence_pct);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns a localized label for an attendance status code.
+     *
+     * @param  int    $status
+     * @return string
+     */
+    protected function status_label(int $status): string {
+        return match ($status) {
+            1 => get_string('statuspresent',     'mod_attendancecontrol'),
+            2 => get_string('statuslate',        'mod_attendancecontrol'),
+            3 => get_string('statusjustified',   'mod_attendancecontrol'),
+            4 => get_string('statusunjustified', 'mod_attendancecontrol'),
+            default => get_string('statuspending', 'mod_attendancecontrol'),
+        };
+    }
+}

--- a/classes/local/session_manager.php
+++ b/classes/local/session_manager.php
@@ -1,0 +1,270 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Session generation and management logic.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol\local;
+
+/**
+ * Handles session generation, regeneration and attendance record persistence.
+ */
+class session_manager {
+
+    /** @var \stdClass Plugin instance record. */
+    protected \stdClass $instance;
+
+    /**
+     * Constructor.
+     *
+     * @param \stdClass $instance  Row from the attendancecontrol table.
+     */
+    public function __construct(\stdClass $instance) {
+        $this->instance = $instance;
+    }
+
+    // -----------------------------------------------------------------------
+    // Session generation.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Generates all sessions for the full date range.
+     *
+     * Called when a new instance is created.
+     */
+    public function generate_sessions(): void {
+        global $DB;
+
+        $slots    = $DB->get_records('attendancecontrol_schedule', ['attendancecontrolid' => $this->instance->id]);
+        $holidays = $this->get_holiday_timestamps();
+
+        $start = (int) $this->instance->course_start_date;
+        $end   = (int) $this->instance->course_end_date;
+
+        $now = time();
+
+        for ($ts = $start; $ts <= $end; $ts = strtotime('+1 day', $ts)) {
+            // ISO day of week (1=Mon … 7=Sun).
+            $dow = (int) date('N', $ts);
+
+            // Skip holidays.
+            if (in_array($ts, $holidays, true)) {
+                continue;
+            }
+
+            foreach ($slots as $slot) {
+                if ((int) $slot->day_of_week !== $dow) {
+                    continue;
+                }
+
+                $duration = self::compute_duration_hours($slot->start_time, $slot->end_time);
+
+                $session = (object) [
+                    'attendancecontrolid' => $this->instance->id,
+                    'session_date'        => $ts,
+                    'start_time'          => $slot->start_time,
+                    'end_time'            => $slot->end_time,
+                    'duration_hours'      => $duration,
+                    'status'              => 0,
+                    'timecreated'         => $now,
+                    'timemodified'        => $now,
+                ];
+
+                $DB->insert_record('attendancecontrol_session', $session);
+            }
+        }
+    }
+
+    /**
+     * Regenerates future sessions that have no attendance records yet.
+     *
+     * Called when an instance is updated. Preserves past sessions and any
+     * future session that already has records attached.
+     */
+    public function regenerate_future_sessions(): void {
+        global $DB;
+
+        $today = mktime(0, 0, 0, (int) date('m'), (int) date('d'), (int) date('Y'));
+
+        // Collect future session IDs with records.
+        $futuresessions = $DB->get_records_select(
+            'attendancecontrol_session',
+            'attendancecontrolid = :id AND session_date >= :today',
+            ['id' => $this->instance->id, 'today' => $today],
+            '',
+            'id'
+        );
+
+        $sessionswithrec = [];
+        foreach ($futuresessions as $s) {
+            if ($DB->record_exists('attendancecontrol_record', ['sessionid' => $s->id])) {
+                $sessionswithrec[] = $s->id;
+            }
+        }
+
+        // Delete future sessions without records.
+        $allids = array_keys($futuresessions);
+        $deletable = array_diff($allids, $sessionswithrec);
+
+        if ($deletable) {
+            [$insql, $inparams] = $DB->get_in_or_equal($deletable);
+            $DB->delete_records_select('attendancecontrol_session', "id $insql", $inparams);
+        }
+
+        // Regenerate from today.
+        $slots    = $DB->get_records('attendancecontrol_schedule', ['attendancecontrolid' => $this->instance->id]);
+        $holidays = $this->get_holiday_timestamps();
+        $end      = (int) $this->instance->course_end_date;
+        $now      = time();
+
+        for ($ts = $today; $ts <= $end; $ts = strtotime('+1 day', $ts)) {
+            $dow = (int) date('N', $ts);
+
+            if (in_array($ts, $holidays, true)) {
+                continue;
+            }
+
+            foreach ($slots as $slot) {
+                if ((int) $slot->day_of_week !== $dow) {
+                    continue;
+                }
+
+                // Skip if a session already exists for this date+time (kept because it has records).
+                if ($DB->record_exists('attendancecontrol_session', [
+                    'attendancecontrolid' => $this->instance->id,
+                    'session_date'        => $ts,
+                    'start_time'          => $slot->start_time,
+                ])) {
+                    continue;
+                }
+
+                $duration = self::compute_duration_hours($slot->start_time, $slot->end_time);
+
+                $session = (object) [
+                    'attendancecontrolid' => $this->instance->id,
+                    'session_date'        => $ts,
+                    'start_time'          => $slot->start_time,
+                    'end_time'            => $slot->end_time,
+                    'duration_hours'      => $duration,
+                    'status'              => 0,
+                    'timecreated'         => $now,
+                    'timemodified'        => $now,
+                ];
+
+                $DB->insert_record('attendancecontrol_session', $session);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Attendance record persistence.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Saves (upserts) attendance records submitted from attendance_form.
+     *
+     * @param \stdClass $session  Session record.
+     * @param \stdClass $data     Form submission data.
+     */
+    public function save_attendance_records(\stdClass $session, \stdClass $data): void {
+        global $DB, $USER;
+
+        if (empty($data->student_status)) {
+            return;
+        }
+
+        $now = time();
+
+        foreach ($data->student_status as $userid => $status) {
+            $remarks = $data->student_remarks[$userid] ?? '';
+
+            $existing = $DB->get_record('attendancecontrol_record', [
+                'sessionid' => $session->id,
+                'userid'    => $userid,
+            ]);
+
+            if ($existing) {
+                $existing->status       = (int) $status;
+                $existing->remarks      = $remarks;
+                $existing->recorded_by  = (int) $USER->id;
+                $existing->timemodified = $now;
+                $DB->update_record('attendancecontrol_record', $existing);
+            } else {
+                $record = (object) [
+                    'sessionid'    => $session->id,
+                    'userid'       => (int) $userid,
+                    'status'       => (int) $status,
+                    'remarks'      => $remarks,
+                    'recorded_by'  => (int) $USER->id,
+                    'timecreated'  => $now,
+                    'timemodified' => $now,
+                ];
+                $DB->insert_record('attendancecontrol_record', $record);
+            }
+        }
+
+        // Mark session as recorded.
+        $DB->set_field('attendancecontrol_session', 'status', 1, ['id' => $session->id]);
+        $DB->set_field('attendancecontrol_session', 'timemodified', $now, ['id' => $session->id]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns an array of holiday timestamps (midnight) for this instance.
+     *
+     * @return int[]
+     */
+    protected function get_holiday_timestamps(): array {
+        global $DB;
+
+        $rows = $DB->get_records(
+            'attendancecontrol_holiday',
+            ['attendancecontrolid' => $this->instance->id],
+            '',
+            'holiday_date'
+        );
+
+        return array_column($rows, 'holiday_date');
+    }
+
+    /**
+     * Computes the session duration in whole hours (ceiling).
+     *
+     * @param  string $start  'HH:MM'
+     * @param  string $end    'HH:MM'
+     * @return int
+     */
+    public static function compute_duration_hours(string $start, string $end): int {
+        [$sh, $sm] = array_map('intval', explode(':', $start));
+        [$eh, $em] = array_map('intval', explode(':', $end));
+
+        $totalminutes = ($eh * 60 + $em) - ($sh * 60 + $sm);
+
+        if ($totalminutes <= 0) {
+            return 0;
+        }
+
+        return (int) ceil($totalminutes / 60);
+    }
+}

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -1,0 +1,236 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Plugin renderer – delegates HTML generation to Mustache templates.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol\output;
+
+use mod_attendancecontrol\local\attendance_calculator;
+use moodle_url;
+use plugin_renderer_base;
+
+/**
+ * Renderer for mod_attendancecontrol.
+ *
+ * All public methods return HTML strings produced via Mustache templates.
+ */
+class renderer extends plugin_renderer_base {
+
+    // -----------------------------------------------------------------------
+    // Teacher views.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Renders the teacher main view (session list + action buttons).
+     *
+     * @param  \stdClass          $instance
+     * @param  \cm_info|\stdClass $cm
+     * @param  \context_module    $context
+     * @return string  HTML
+     */
+    public function render_teacher_view(\stdClass $instance, $cm, \context_module $context): string {
+        global $DB;
+
+        // Week navigation parameter.
+        $weekoffset = optional_param('week', 0, PARAM_INT);
+        $monday     = strtotime('monday this week', strtotime("+{$weekoffset} weeks"));
+        $sunday     = strtotime('+6 days', $monday);
+
+        $sessions = $DB->get_records_select(
+            'attendancecontrol_session',
+            'attendancecontrolid = :id AND session_date >= :start AND session_date <= :end',
+            ['id' => $instance->id, 'start' => $monday, 'end' => $sunday],
+            'session_date ASC, start_time ASC'
+        );
+
+        $today = mktime(0, 0, 0, (int) date('m'), (int) date('d'), (int) date('Y'));
+
+        $sessiondata = [];
+        foreach ($sessions as $s) {
+            $sessiondata[] = [
+                'id'           => $s->id,
+                'cmid'         => $cm->id,
+                'date_label'   => userdate($s->session_date, get_string('strftimedaydate')),
+                'schedule'     => $s->start_time . '–' . $s->end_time,
+                'is_today'     => ((int) $s->session_date === $today),
+                'is_recorded'  => ((int) $s->status === 1),
+                'status_label' => ((int) $s->status === 1)
+                    ? get_string('statusrecorded', 'mod_attendancecontrol')
+                    : get_string('statuspending', 'mod_attendancecontrol'),
+                'url_record'   => (new moodle_url('/mod/attendancecontrol/attendance.php',
+                    ['id' => $cm->id, 'sessionid' => $s->id]))->out(false),
+            ];
+        }
+
+        $data = [
+            'cmid'         => $cm->id,
+            'url_today'    => (new moodle_url('/mod/attendancecontrol/attendance.php', ['id' => $cm->id]))->out(false),
+            'url_report'   => (new moodle_url('/mod/attendancecontrol/report.php',    ['id' => $cm->id]))->out(false),
+            'url_prevweek' => (new moodle_url('/mod/attendancecontrol/view.php',
+                ['id' => $cm->id, 'week' => $weekoffset - 1]))->out(false),
+            'url_nextweek' => (new moodle_url('/mod/attendancecontrol/view.php',
+                ['id' => $cm->id, 'week' => $weekoffset + 1]))->out(false),
+            'week_label'   => userdate($monday, get_string('strftimedatefullshort')) . ' – ' .
+                              userdate($sunday, get_string('strftimedatefullshort')),
+            'sessions'     => array_values($sessiondata),
+            'hassessions'  => !empty($sessiondata),
+            'str_register' => get_string('registerattendancetoday', 'mod_attendancecontrol'),
+            'str_report'   => get_string('viewfulldata', 'mod_attendancecontrol'),
+            'str_prev'     => get_string('previousweek', 'mod_attendancecontrol'),
+            'str_next'     => get_string('nextweek', 'mod_attendancecontrol'),
+        ];
+
+        return $this->render_from_template('mod_attendancecontrol/session_list', $data);
+    }
+
+    /**
+     * Renders the summary table (report.php).
+     *
+     * @param  array              $summary   Output of attendance_calculator::get_group_summary().
+     * @param  \stdClass          $instance
+     * @param  \cm_info|\stdClass $cm
+     * @return string  HTML
+     */
+    public function render_summary_table(array $summary, \stdClass $instance, $cm): string {
+        $calculator = new attendance_calculator($instance);
+        $threshold  = $calculator->get_threshold();
+
+        $rows = [];
+        foreach ($summary as $data) {
+            $rows[] = [
+                'student_name'     => fullname($data['student']),
+                'userid'           => $data['student']->id,
+                'url_detail'       => (new moodle_url('/mod/attendancecontrol/student_detail.php',
+                    ['id' => $cm->id, 'userid' => $data['student']->id]))->out(false),
+                'presences'        => $data['presences'],
+                'lates'            => $data['lates'],
+                'justified'        => $data['justified'],
+                'unjustified'      => $data['unjustified'],
+                'equiv_hours'      => number_format($data['equiv_hours'], 1),
+                'pct'              => number_format($data['pct'], 1),
+                'below_threshold'  => $data['below_threshold'],
+            ];
+        }
+
+        $data = [
+            'rows'           => $rows,
+            'url_export'     => (new moodle_url('/mod/attendancecontrol/export.php', ['id' => $cm->id]))->out(false),
+            'threshold_notice' => get_string('thresholdnotice', 'mod_attendancecontrol', (object) [
+                'threshold' => number_format($threshold, 1),
+                'pct'       => number_format((float) $instance->max_unjustified_absence_pct, 1),
+                'hours'     => $instance->total_hours,
+            ]),
+            'str_export'     => get_string('exportexcel', 'mod_attendancecontrol'),
+        ];
+
+        return $this->render_from_template('mod_attendancecontrol/summary_table', $data);
+    }
+
+    /**
+     * Renders the per-student session-by-session detail view.
+     *
+     * @param  array     $detail   Output of attendance_calculator::get_student_detail().
+     * @param  \stdClass $instance
+     * @param  \stdClass $student  Moodle user object.
+     * @return string  HTML
+     */
+    public function render_student_detail(array $detail, \stdClass $instance, \stdClass $student): string {
+        $calculator = new attendance_calculator($instance);
+        $pct        = $calculator->compute_attendance_pct((int) $student->id);
+        $threshold  = $calculator->get_threshold();
+
+        $rows = [];
+        foreach ($detail as $item) {
+            $statuskey = match ((int) ($item['record']->status ?? 0)) {
+                1 => 'statuspresent',
+                2 => 'statuslate',
+                3 => 'statusjustified',
+                4 => 'statusunjustified',
+                default => 'statuspending',
+            };
+            $rows[] = [
+                'date'         => userdate($item['session']->session_date, get_string('strftimedaydate')),
+                'schedule'     => $item['session']->start_time . '–' . $item['session']->end_time,
+                'duration'     => $item['session']->duration_hours,
+                'status_label' => get_string($statuskey, 'mod_attendancecontrol'),
+                'status_code'  => (int) ($item['record']->status ?? 0),
+                'remarks'      => $item['record']->remarks ?? '',
+            ];
+        }
+
+        $data = [
+            'student_name'    => fullname($student),
+            'pct'             => number_format($pct, 1),
+            'below_threshold' => $pct < $threshold,
+            'rows'            => $rows,
+        ];
+
+        return $this->render_from_template('mod_attendancecontrol/student_detail', $data);
+    }
+
+    // -----------------------------------------------------------------------
+    // Student view.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Renders the student's personal attendance summary.
+     *
+     * @param  \stdClass          $instance
+     * @param  \cm_info|\stdClass $cm
+     * @param  \context_module    $context
+     * @return string  HTML
+     */
+    public function render_student_view(\stdClass $instance, $cm, \context_module $context): string {
+        global $USER;
+
+        $calculator = new attendance_calculator($instance);
+        $summary    = null;
+
+        // Find this student's summary row.
+        foreach ($calculator->get_group_summary() as $row) {
+            if ((int) $row['student']->id === (int) $USER->id) {
+                $summary = $row;
+                break;
+            }
+        }
+
+        if ($summary === null) {
+            return $this->output->notification(get_string('nostudentview', 'mod_attendancecontrol'));
+        }
+
+        $threshold = $calculator->get_threshold();
+
+        $data = [
+            'presences'       => $summary['presences'],
+            'lates'           => $summary['lates'],
+            'justified'       => $summary['justified'],
+            'unjustified'     => $summary['unjustified'],
+            'pct'             => number_format($summary['pct'], 1),
+            'below_threshold' => $summary['below_threshold'],
+            'url_breakdown'   => (new moodle_url('/mod/attendancecontrol/student_detail.php',
+                ['id' => $cm->id, 'userid' => $USER->id]))->out(false),
+            'str_breakdown'   => get_string('viewbreakdown', 'mod_attendancecontrol'),
+        ];
+
+        return $this->render_from_template('mod_attendancecontrol/student_summary', $data);
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,291 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Privacy API provider for mod_attendancecontrol.
+ *
+ * Declares what personal data is stored, and implements export and deletion
+ * so that site administrators can comply with GDPR requests.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol\privacy;
+
+use core_privacy\local\metadata\collection;
+use core_privacy\local\request\approved_contextlist;
+use core_privacy\local\request\approved_userlist;
+use core_privacy\local\request\contextlist;
+use core_privacy\local\request\helper;
+use core_privacy\local\request\userlist;
+use core_privacy\local\request\writer;
+
+/**
+ * Privacy provider implementation.
+ *
+ * Personal data stored: attendancecontrol_record (userid, status, remarks,
+ * recorded_by, timecreated, timemodified).
+ */
+class provider implements
+    \core_privacy\local\metadata\provider,
+    \core_privacy\local\request\core_userlist_provider,
+    \core_privacy\local\request\plugin\provider {
+
+    // -----------------------------------------------------------------------
+    // Metadata.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Describes the personal data stored by this plugin.
+     *
+     * @param  collection $collection
+     * @return collection
+     */
+    public static function get_metadata(collection $collection): collection {
+        $collection->add_database_table(
+            'attendancecontrol_record',
+            [
+                'userid'       => 'privacy:metadata:attendancecontrol_record:userid',
+                'status'       => 'privacy:metadata:attendancecontrol_record:status',
+                'remarks'      => 'privacy:metadata:attendancecontrol_record:remarks',
+                'recorded_by'  => 'privacy:metadata:attendancecontrol_record:recorded_by',
+                'timecreated'  => 'privacy:metadata:attendancecontrol_record:timecreated',
+                'timemodified' => 'privacy:metadata:attendancecontrol_record:timemodified',
+            ],
+            'privacy:metadata:attendancecontrol_record'
+        );
+
+        return $collection;
+    }
+
+    // -----------------------------------------------------------------------
+    // Context discovery.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the contexts that contain personal data for the given user.
+     *
+     * @param  int          $userid
+     * @return contextlist
+     */
+    public static function get_contexts_for_userid(int $userid): contextlist {
+        $contextlist = new contextlist();
+
+        $sql = '
+            SELECT DISTINCT ctx.id
+              FROM {context}               ctx
+              JOIN {course_modules}        cm  ON cm.id = ctx.instanceid
+                                              AND ctx.contextlevel = :ctxlevel
+              JOIN {attendancecontrol}     ac  ON ac.id = cm.instance
+              JOIN {attendancecontrol_session} s ON s.attendancecontrolid = ac.id
+              JOIN {attendancecontrol_record}  r ON r.sessionid = s.id
+             WHERE r.userid = :userid
+        ';
+
+        $contextlist->add_from_sql($sql, [
+            'ctxlevel' => CONTEXT_MODULE,
+            'userid'   => $userid,
+        ]);
+
+        return $contextlist;
+    }
+
+    /**
+     * Returns the list of users in the given context who have personal data.
+     *
+     * @param  userlist $userlist
+     */
+    public static function get_users_in_context(userlist $userlist): void {
+        $context = $userlist->get_context();
+
+        if (!$context instanceof \context_module) {
+            return;
+        }
+
+        $sql = '
+            SELECT r.userid
+              FROM {attendancecontrol_record}  r
+              JOIN {attendancecontrol_session} s  ON s.id = r.sessionid
+              JOIN {course_modules}            cm ON cm.instance = s.attendancecontrolid
+             WHERE cm.id = :cmid
+        ';
+
+        $userlist->add_from_sql('userid', $sql, ['cmid' => $context->instanceid]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Export.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Exports all personal data for the given approved context list.
+     *
+     * @param approved_contextlist $contextlist
+     */
+    public static function export_user_data(approved_contextlist $contextlist): void {
+        global $DB;
+
+        $userid = $contextlist->get_user()->id;
+
+        foreach ($contextlist->get_contexts() as $context) {
+            if (!$context instanceof \context_module) {
+                continue;
+            }
+
+            $cm = get_coursemodule_from_id('attendancecontrol', $context->instanceid, 0, false, MUST_EXIST);
+
+            $sql = '
+                SELECT r.id, s.session_date, s.start_time, s.end_time, s.duration_hours,
+                       r.status, r.remarks, r.timecreated, r.timemodified
+                  FROM {attendancecontrol_record}  r
+                  JOIN {attendancecontrol_session} s ON s.id = r.sessionid
+                 WHERE r.userid = :userid
+                   AND s.attendancecontrolid = :instanceid
+              ORDER BY s.session_date ASC, s.start_time ASC
+            ';
+
+            $records = $DB->get_records_sql($sql, [
+                'userid'     => $userid,
+                'instanceid' => $cm->instance,
+            ]);
+
+            $data = [];
+            foreach ($records as $rec) {
+                $data[] = [
+                    'session_date'   => userdate($rec->session_date),
+                    'start_time'     => $rec->start_time,
+                    'end_time'       => $rec->end_time,
+                    'duration_hours' => $rec->duration_hours,
+                    'status'         => $rec->status,
+                    'remarks'        => $rec->remarks,
+                    'timecreated'    => userdate($rec->timecreated),
+                    'timemodified'   => userdate($rec->timemodified),
+                ];
+            }
+
+            writer::with_context($context)->export_data(
+                [get_string('modulename', 'mod_attendancecontrol')],
+                (object) ['records' => $data]
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Deletion.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Deletes all personal data for a specific context (all users).
+     *
+     * @param \context $context
+     */
+    public static function delete_data_for_all_users_in_context(\context $context): void {
+        global $DB;
+
+        if (!$context instanceof \context_module) {
+            return;
+        }
+
+        $cm = get_coursemodule_from_id('attendancecontrol', $context->instanceid, 0, false, MUST_EXIST);
+
+        $sessionids = $DB->get_fieldset_select(
+            'attendancecontrol_session',
+            'id',
+            'attendancecontrolid = :id',
+            ['id' => $cm->instance]
+        );
+
+        if ($sessionids) {
+            [$insql, $inparams] = $DB->get_in_or_equal($sessionids);
+            $DB->delete_records_select('attendancecontrol_record', "sessionid $insql", $inparams);
+        }
+    }
+
+    /**
+     * Deletes all personal data for the given approved context list (one user).
+     *
+     * @param approved_contextlist $contextlist
+     */
+    public static function delete_data_for_user(approved_contextlist $contextlist): void {
+        global $DB;
+
+        $userid = $contextlist->get_user()->id;
+
+        foreach ($contextlist->get_contexts() as $context) {
+            if (!$context instanceof \context_module) {
+                continue;
+            }
+
+            $cm = get_coursemodule_from_id('attendancecontrol', $context->instanceid, 0, false, MUST_EXIST);
+
+            $sessionids = $DB->get_fieldset_select(
+                'attendancecontrol_session',
+                'id',
+                'attendancecontrolid = :id',
+                ['id' => $cm->instance]
+            );
+
+            if ($sessionids) {
+                [$insql, $inparams] = $DB->get_in_or_equal($sessionids);
+                $inparams['userid'] = $userid;
+                $DB->delete_records_select(
+                    'attendancecontrol_record',
+                    "sessionid $insql AND userid = :userid",
+                    $inparams
+                );
+            }
+        }
+    }
+
+    /**
+     * Deletes personal data for multiple users within a single context.
+     *
+     * @param approved_userlist $userlist
+     */
+    public static function delete_data_for_users(approved_userlist $userlist): void {
+        global $DB;
+
+        $context = $userlist->get_context();
+
+        if (!$context instanceof \context_module) {
+            return;
+        }
+
+        $cm = get_coursemodule_from_id('attendancecontrol', $context->instanceid, 0, false, MUST_EXIST);
+
+        $sessionids = $DB->get_fieldset_select(
+            'attendancecontrol_session',
+            'id',
+            'attendancecontrolid = :id',
+            ['id' => $cm->instance]
+        );
+
+        if (!$sessionids) {
+            return;
+        }
+
+        [$sessql, $sesparams] = $DB->get_in_or_equal($sessionids, SQL_PARAMS_NAMED);
+        [$usersql, $userparams] = $DB->get_in_or_equal($userlist->get_userids(), SQL_PARAMS_NAMED);
+
+        $DB->delete_records_select(
+            'attendancecontrol_record',
+            "sessionid $sessql AND userid $usersql",
+            array_merge($sesparams, $userparams)
+        );
+    }
+}

--- a/db/access.php
+++ b/db/access.php
@@ -1,0 +1,93 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Capability definitions for mod_attendancecontrol.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$capabilities = [
+
+    // Add the activity to a course.
+    'mod/attendancecontrol:addinstance' => [
+        'riskbitmask'  => RISK_XSS,
+        'captype'      => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes'   => [
+            'editingteacher' => CAP_ALLOW,
+            'manager'        => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'moodle/course:manageactivities',
+    ],
+
+    // View full attendance summary for all students.
+    'mod/attendancecontrol:viewsummary' => [
+        'captype'      => 'read',
+        'contextlevel' => CONTEXT_MODULE,
+        'archetypes'   => [
+            'editingteacher' => CAP_ALLOW,
+            'manager'        => CAP_ALLOW,
+            'teacher'        => CAP_ALLOW,  // Non-editing teacher.
+        ],
+    ],
+
+    // Record and edit attendance.
+    'mod/attendancecontrol:recordattendance' => [
+        'riskbitmask'  => RISK_PERSONAL,
+        'captype'      => 'write',
+        'contextlevel' => CONTEXT_MODULE,
+        'archetypes'   => [
+            'editingteacher' => CAP_ALLOW,
+            'manager'        => CAP_ALLOW,
+        ],
+    ],
+
+    // View own attendance data (students).
+    'mod/attendancecontrol:viewownattendance' => [
+        'captype'      => 'read',
+        'contextlevel' => CONTEXT_MODULE,
+        'archetypes'   => [
+            'student' => CAP_ALLOW,
+        ],
+    ],
+
+    // Export attendance data to Excel.
+    'mod/attendancecontrol:export' => [
+        'captype'      => 'read',
+        'contextlevel' => CONTEXT_MODULE,
+        'archetypes'   => [
+            'editingteacher' => CAP_ALLOW,
+            'manager'        => CAP_ALLOW,
+            'teacher'        => CAP_ALLOW,
+        ],
+    ],
+
+    // Manage (add/edit/delete) future sessions.
+    'mod/attendancecontrol:managesessions' => [
+        'riskbitmask'  => RISK_PERSONAL,
+        'captype'      => 'write',
+        'contextlevel' => CONTEXT_MODULE,
+        'archetypes'   => [
+            'editingteacher' => CAP_ALLOW,
+            'manager'        => CAP_ALLOW,
+        ],
+    ],
+];

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="mod/attendancecontrol/db" VERSION="20260218" COMMENT="XMLDB file for mod/attendancecontrol"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd">
+  <TABLES>
+    <!--
+      Main instance table.
+      One record per activity instance added to a course.
+    -->
+    <TABLE NAME="attendancecontrol" COMMENT="Each attendancecontrol activity instance">
+      <FIELDS>
+        <FIELD NAME="id"                          TYPE="int"    LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="course"                      TYPE="int"    LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Course ID"/>
+        <FIELD NAME="name"                        TYPE="char"   LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="intro"                       TYPE="text"               NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="introformat"                 TYPE="int"    LENGTH="4"  NOTNULL="true"  DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="groupid"                     TYPE="int"    LENGTH="10" NOTNULL="true"  SEQUENCE="false" COMMENT="Moodle group ID"/>
+        <FIELD NAME="total_hours"                 TYPE="int"    LENGTH="5"  NOTNULL="true"  SEQUENCE="false"/>
+        <FIELD NAME="course_start_date"           TYPE="int"    LENGTH="10" NOTNULL="true"  SEQUENCE="false" COMMENT="Unix timestamp"/>
+        <FIELD NAME="course_end_date"             TYPE="int"    LENGTH="10" NOTNULL="true"  SEQUENCE="false" COMMENT="Unix timestamp"/>
+        <FIELD NAME="max_unjustified_absence_pct" TYPE="number" LENGTH="5"  NOTNULL="true"  SEQUENCE="false" DECIMALS="2" DEFAULT="15.00"/>
+        <FIELD NAME="delay_to_unjustified_ratio"  TYPE="number" LENGTH="5"  NOTNULL="true"  SEQUENCE="false" DECIMALS="2" DEFAULT="0.50"/>
+        <FIELD NAME="justified_to_unjustified_ratio" TYPE="number" LENGTH="5" NOTNULL="true" SEQUENCE="false" DECIMALS="2" DEFAULT="0.50"/>
+        <FIELD NAME="timecreated"                 TYPE="int"    LENGTH="10" NOTNULL="true"  SEQUENCE="false"/>
+        <FIELD NAME="timemodified"                TYPE="int"    LENGTH="10" NOTNULL="true"  SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="fk_course" TYPE="foreign" FIELDS="course" REFTABLE="course" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="idx_course" UNIQUE="false" FIELDS="course"/>
+      </INDEXES>
+    </TABLE>
+
+    <!--
+      Weekly schedule slots (recurrent, one per day+time combination).
+    -->
+    <TABLE NAME="attendancecontrol_schedule" COMMENT="Weekly recurring time slots for a plugin instance">
+      <FIELDS>
+        <FIELD NAME="id"                   TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="attendancecontrolid"  TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="day_of_week"          TYPE="int"  LENGTH="1"  NOTNULL="true" SEQUENCE="false" COMMENT="1=Mon … 7=Sun"/>
+        <FIELD NAME="start_time"           TYPE="char" LENGTH="5"  NOTNULL="true" SEQUENCE="false" COMMENT="HH:MM"/>
+        <FIELD NAME="end_time"             TYPE="char" LENGTH="5"  NOTNULL="true" SEQUENCE="false" COMMENT="HH:MM"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="fk_instance" TYPE="foreign" FIELDS="attendancecontrolid" REFTABLE="attendancecontrol" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="idx_instance" UNIQUE="false" FIELDS="attendancecontrolid"/>
+      </INDEXES>
+    </TABLE>
+
+    <!--
+      Holidays configured per instance.
+    -->
+    <TABLE NAME="attendancecontrol_holiday" COMMENT="Non-teaching days (holidays) for a plugin instance">
+      <FIELDS>
+        <FIELD NAME="id"                   TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="attendancecontrolid"  TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="holiday_date"         TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Unix timestamp (midnight)"/>
+        <FIELD NAME="description"          TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="fk_instance" TYPE="foreign" FIELDS="attendancecontrolid" REFTABLE="attendancecontrol" REFFIELDS="id"/>
+      </KEYS>
+    </TABLE>
+
+    <!--
+      Generated sessions (one per schedule slot × calendar day, excluding holidays).
+    -->
+    <TABLE NAME="attendancecontrol_session" COMMENT="Individual teaching sessions generated from the schedule">
+      <FIELDS>
+        <FIELD NAME="id"                   TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="attendancecontrolid"  TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="session_date"         TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Unix timestamp (midnight)"/>
+        <FIELD NAME="start_time"           TYPE="char" LENGTH="5"  NOTNULL="true" SEQUENCE="false" COMMENT="HH:MM"/>
+        <FIELD NAME="end_time"             TYPE="char" LENGTH="5"  NOTNULL="true" SEQUENCE="false" COMMENT="HH:MM"/>
+        <FIELD NAME="duration_hours"       TYPE="int"  LENGTH="3"  NOTNULL="true" SEQUENCE="false" COMMENT="ceil(duration_minutes/60)"/>
+        <FIELD NAME="status"               TYPE="int"  LENGTH="1"  NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="0=pending 1=recorded"/>
+        <FIELD NAME="timecreated"          TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified"         TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="fk_instance" TYPE="foreign" FIELDS="attendancecontrolid" REFTABLE="attendancecontrol" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="idx_instance_date" UNIQUE="false" FIELDS="attendancecontrolid, session_date"/>
+      </INDEXES>
+    </TABLE>
+
+    <!--
+      Attendance records (one per student × session).
+    -->
+    <TABLE NAME="attendancecontrol_record" COMMENT="Individual student attendance record per session">
+      <FIELDS>
+        <FIELD NAME="id"           TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="sessionid"    TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="userid"       TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Student user ID"/>
+        <FIELD NAME="status"       TYPE="int"  LENGTH="1"  NOTNULL="true" DEFAULT="0" SEQUENCE="false"
+               COMMENT="0=unregistered 1=present 2=late 3=justified 4=unjustified"/>
+        <FIELD NAME="remarks"      TYPE="text"             NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="recorded_by"  TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Teacher user ID"/>
+        <FIELD NAME="timecreated"  TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int"  LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="fk_session" TYPE="foreign" FIELDS="sessionid" REFTABLE="attendancecontrol_session" REFFIELDS="id"/>
+        <KEY NAME="fk_user"    TYPE="foreign" FIELDS="userid"    REFTABLE="user"                      REFFIELDS="id"/>
+        <KEY NAME="uq_session_user" TYPE="unique" FIELDS="sessionid, userid"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="idx_session_user" UNIQUE="false" FIELDS="sessionid, userid"/>
+        <INDEX NAME="idx_user"         UNIQUE="false" FIELDS="userid"/>
+      </INDEXES>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/db/services.php
+++ b/db/services.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * External web services declarations for mod_attendancecontrol.
+ *
+ * No external services are exposed in v1. This file is kept as a
+ * placeholder for future REST/WS endpoints.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$functions = [];
+$services  = [];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,37 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Database upgrade steps for mod_attendancecontrol.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Executes pending upgrade steps.
+ *
+ * @param  int  $oldversion  Previously installed plugin version.
+ * @return bool
+ */
+function xmldb_attendancecontrol_upgrade(int $oldversion): bool {
+    // No upgrade steps required for v1.0.0.
+    // Add future migration blocks here as:
+    //   if ($oldversion < YYYYMMDDXX) { … upgrade_mod_savepoint(…); }
+
+    return true;
+}

--- a/export.php
+++ b/export.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Excel export handler.
+ *
+ * Streams a three-sheet Excel workbook directly to the browser:
+ *   Sheet 1 – Summary (one row per student).
+ *   Sheet 2 – Session detail (one row per student × session).
+ *   Sheet 3 – Configuration parameters.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+
+$id = required_param('id', PARAM_INT); // Course-module ID.
+
+[$course, $cm] = get_course_and_cm_from_cmid($id, 'attendancecontrol');
+
+require_login($course, true, $cm);
+
+$context  = context_module::instance($cm->id);
+$instance = $DB->get_record('attendancecontrol', ['id' => $cm->instance], '*', MUST_EXIST);
+
+require_capability('mod/attendancecontrol:export', $context);
+
+$manager = new \mod_attendancecontrol\local\export_manager($instance);
+$manager->send_excel();
+// send_excel() calls exit() after streaming the file.

--- a/index.php
+++ b/index.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Lists all mod_attendancecontrol instances in a course.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+
+$id = required_param('id', PARAM_INT); // Course ID.
+
+$course = $DB->get_record('course', ['id' => $id], '*', MUST_EXIST);
+
+require_course_login($course);
+
+$PAGE->set_url('/mod/attendancecontrol/index.php', ['id' => $id]);
+$PAGE->set_title(format_string($course->fullname));
+$PAGE->set_heading(format_string($course->fullname));
+$PAGE->set_context(context_course::instance($course->id));
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('modulenameplural', 'mod_attendancecontrol'));
+
+$instances = get_all_instances_in_course('attendancecontrol', $course);
+
+if (empty($instances)) {
+    notice(get_string('noneactiveyet'), new moodle_url('/course/view.php', ['id' => $course->id]));
+}
+
+$table = new html_table();
+$table->attributes['class'] = 'generaltable';
+$table->head  = [
+    get_string('name'),
+    get_string('section'),
+];
+$table->align = ['left', 'left'];
+
+foreach ($instances as $instance) {
+    $link = html_writer::link(
+        new moodle_url('/mod/attendancecontrol/view.php', ['id' => $instance->coursemodule]),
+        format_string($instance->name, true, ['context' => context_module::instance($instance->coursemodule)])
+    );
+
+    $table->data[] = [$link, $instance->section];
+}
+
+echo html_writer::table($table);
+echo $OUTPUT->footer();

--- a/lang/es/attendancecontrol.php
+++ b/lang/es/attendancecontrol.php
@@ -1,0 +1,148 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Spanish language strings for mod_attendancecontrol.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+// ── Plugin identity ──────────────────────────────────────────────────────────
+$string['modulename']        = 'Control de Asistencia';
+$string['modulenameplural']  = 'Controles de Asistencia';
+$string['modulename_help']   = 'El módulo Control de Asistencia permite registrar la asistencia diaria del alumnado, consultar resúmenes con porcentajes y exportar los datos a Excel.';
+$string['pluginname']        = 'Control de Asistencia';
+$string['pluginadministration'] = 'Administración de Control de Asistencia';
+
+// ── mod_form: secciones y campos ─────────────────────────────────────────────
+$string['group']                   = 'Grupo de alumnos';
+$string['group_help']              = 'Selecciona el grupo de Moodle cuyos miembros formarán parte de la lista de asistencia.';
+$string['daterange']               = 'Rango de fechas del curso';
+$string['coursestartdate']         = 'Fecha de inicio';
+$string['courseenddate']           = 'Fecha de fin';
+$string['totalhours']              = 'Horas totales de la asignatura';
+$string['schedule']                = 'Franjas horarias semanales';
+$string['dayofweek']               = 'Día de la semana';
+$string['starttime']               = 'Hora de inicio (HH:MM)';
+$string['endtime']                 = 'Hora de fin (HH:MM)';
+$string['addslot']                 = 'Añadir otra franja horaria';
+$string['holidays']                = 'Festivos';
+$string['holidaydate']             = 'Fecha del festivo';
+$string['holidaydescription']      = 'Descripción (opcional)';
+$string['addholiday']              = 'Añadir festivo';
+$string['penaltyconfig']           = 'Configuración de penalización';
+$string['maxunjustifiedpct']       = '% máximo de faltas permitido';
+$string['maxunjustifiedpct_help']  = 'Porcentaje máximo de horas equivalentes de falta injustificada sobre el total de horas. Por encima de este umbral el alumno se muestra en rojo.';
+$string['delayratio']              = 'Ratio retraso → falta injustificada';
+$string['delayratio_help']         = 'Un retraso cuenta como esta fracción de una hora de falta injustificada. Ejemplo: 0,5 significa que un retraso de 1 hora cuenta como 0,5 horas de falta injustificada.';
+$string['justifiedratio']          = 'Ratio falta justificada → falta injustificada';
+$string['justifiedratio_help']     = 'Una falta justificada cuenta como esta fracción de una hora de falta injustificada. Ejemplo: 0,5 significa que 1 hora justificada cuenta como 0,5 horas de falta injustificada.';
+
+// ── Validation errors ────────────────────────────────────────────────────────
+$string['err_enddatebeforestart'] = 'La fecha de fin debe ser posterior a la de inicio.';
+$string['err_hourspositive']      = 'Las horas totales deben ser un número positivo.';
+$string['err_invalidratio']       = 'El valor debe estar entre 0 y 100.';
+
+// ── view.php ─────────────────────────────────────────────────────────────────
+$string['registerattendancetoday'] = 'Registrar asistencia hoy';
+$string['viewfulldata']            = 'Ver datos completos';
+$string['sessionsthisweek']        = 'Sesiones de esta semana';
+$string['previousweek']           = '◄ Semana anterior';
+$string['nextweek']               = 'Semana siguiente ►';
+$string['nostudentview']          = 'No tienes permisos para ver esta actividad.';
+
+// ── Session list ─────────────────────────────────────────────────────────────
+$string['sessiondate']      = 'Fecha';
+$string['sessionschedule']  = 'Horario';
+$string['sessionstatus']    = 'Estado';
+$string['statuspending']    = 'Pendiente';
+$string['statusrecorded']   = 'Registrada';
+
+// ── attendance.php ───────────────────────────────────────────────────────────
+$string['recordattendance']  = 'Registrar asistencia';
+$string['sessionheading']    = 'Sesión: {$a}';
+$string['markallpresent']    = 'Marcar todos como:';
+$string['studentname']       = 'Alumno/a';
+$string['statuspresent']     = 'Presente';
+$string['statuslate']        = 'Retraso';
+$string['statusjustified']   = 'F. Justificada';
+$string['statusunjustified'] = 'F. Injustificada';
+$string['remarks']           = 'Observaciones';
+$string['saveattendance']    = 'Guardar asistencia';
+$string['attendancesaved']   = 'Asistencia guardada correctamente.';
+
+// ── report.php ───────────────────────────────────────────────────────────────
+$string['reporttitle']          = 'Resumen de asistencia';
+$string['presences']            = 'Presencias';
+$string['lates']                = 'Retrasos';
+$string['justifiedabsences']    = 'F. Justificadas';
+$string['unjustifiedabsences']  = 'F. Injustificadas';
+$string['equivalenthours']      = 'H. Equiv. Falta';
+$string['attendancepct']        = '% Asistencia';
+$string['exportexcel']          = 'Exportar a Excel';
+$string['thresholdnotice']      = 'Umbral configurado: {$a->threshold}% ({$a->pct}% de faltas máximo sobre {$a->hours}h)';
+
+// ── student_detail.php ───────────────────────────────────────────────────────
+$string['studentdetailtitle']    = 'Detalle de asistencia';
+$string['myattendance']          = 'Mi asistencia';
+$string['viewbreakdown']         = 'Ver desglose por sesión';
+$string['alertthresholdreached'] = '¡Atención! Has superado el umbral máximo de faltas permitido.';
+$string['sessionbreakdown']      = 'Desglose por sesión';
+
+// ── export.php ───────────────────────────────────────────────────────────────
+$string['excel_sheet_summary']       = 'Resumen';
+$string['excel_sheet_detail']        = 'Detalle por sesión';
+$string['excel_sheet_config']        = 'Configuración';
+$string['excel_col_student']         = 'Alumno/a';
+$string['excel_col_date']            = 'Fecha';
+$string['excel_col_schedule']        = 'Horario';
+$string['excel_col_duration']        = 'Duración (h)';
+$string['excel_col_status']          = 'Estado';
+$string['excel_col_remarks']         = 'Observaciones';
+$string['excel_col_equivhours']      = 'Horas equiv. falta';
+$string['excel_col_pct']             = '% Asistencia';
+$string['excel_param_subject']       = 'Asignatura';
+$string['excel_param_group']         = 'Grupo';
+$string['excel_param_totalhours']    = 'Horas totales';
+$string['excel_param_delayratio']    = 'Ratio retraso';
+$string['excel_param_justifiedratio']= 'Ratio falta justificada';
+$string['excel_param_maxpct']        = '% máximo faltas permitido';
+
+// ── Capabilities (shown in role administration) ──────────────────────────────
+$string['attendancecontrol:addinstance']       = 'Añadir una instancia de Control de Asistencia';
+$string['attendancecontrol:viewsummary']       = 'Ver resumen de asistencia del grupo';
+$string['attendancecontrol:recordattendance']  = 'Registrar y editar asistencia';
+$string['attendancecontrol:viewownattendance'] = 'Ver la propia asistencia';
+$string['attendancecontrol:export']            = 'Exportar datos de asistencia a Excel';
+$string['attendancecontrol:managesessions']    = 'Gestionar sesiones futuras';
+
+// ── Events ───────────────────────────────────────────────────────────────────
+$string['eventattendancerecorded']   = 'Asistencia registrada';
+$string['eventcoursemodudeviewed']   = 'Control de asistencia visto';
+$string['eventsessioncreated']       = 'Sesión creada';
+
+// ── Privacy ──────────────────────────────────────────────────────────────────
+$string['privacy:metadata:attendancecontrol_record']              = 'Almacena el registro de asistencia de cada alumno por sesión.';
+$string['privacy:metadata:attendancecontrol_record:userid']       = 'El ID del usuario (alumno) al que corresponde el registro.';
+$string['privacy:metadata:attendancecontrol_record:status']       = 'Estado de asistencia (presente, retraso, justificada, injustificada).';
+$string['privacy:metadata:attendancecontrol_record:remarks']      = 'Observaciones introducidas por el profesor.';
+$string['privacy:metadata:attendancecontrol_record:recorded_by']  = 'ID del profesor que registró la asistencia.';
+$string['privacy:metadata:attendancecontrol_record:timecreated']  = 'Marca de tiempo de creación del registro.';
+$string['privacy:metadata:attendancecontrol_record:timemodified'] = 'Marca de tiempo de última modificación.';

--- a/lib.php
+++ b/lib.php
@@ -1,0 +1,213 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Standard Moodle module callbacks for mod_attendancecontrol.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+// ---------------------------------------------------------------------------
+// CRUD callbacks required by Moodle.
+// ---------------------------------------------------------------------------
+
+/**
+ * Adds a new instance of attendancecontrol.
+ *
+ * Called by the course module form when a new instance is saved for the
+ * first time. Generates all sessions automatically.
+ *
+ * @param  stdClass $data  Form data from mod_form.php.
+ * @return int             New instance ID.
+ */
+function attendancecontrol_add_instance(stdClass $data): int {
+    global $DB;
+
+    $data->timecreated  = time();
+    $data->timemodified = time();
+
+    // Persist base record.
+    $instanceid = $DB->insert_record('attendancecontrol', $data);
+    $data->id   = $instanceid;
+
+    // Persist schedule slots submitted via the repeatable element.
+    attendancecontrol_save_schedule($data);
+
+    // Persist holiday dates.
+    attendancecontrol_save_holidays($data);
+
+    // Auto-generate sessions.
+    $manager = new \mod_attendancecontrol\local\session_manager($data);
+    $manager->generate_sessions();
+
+    return $instanceid;
+}
+
+/**
+ * Updates an existing instance of attendancecontrol.
+ *
+ * Regenerates future sessions (without attendance records) when the
+ * schedule or date range changes.
+ *
+ * @param  stdClass $data  Form data from mod_form.php.
+ * @return bool
+ */
+function attendancecontrol_update_instance(stdClass $data): bool {
+    global $DB;
+
+    $data->id           = $data->instance;
+    $data->timemodified = time();
+
+    $DB->update_record('attendancecontrol', $data);
+
+    // Re-save schedule (delete old, insert new).
+    $DB->delete_records('attendancecontrol_schedule', ['attendancecontrolid' => $data->id]);
+    attendancecontrol_save_schedule($data);
+
+    // Re-save holidays (delete old, insert new).
+    $DB->delete_records('attendancecontrol_holiday', ['attendancecontrolid' => $data->id]);
+    attendancecontrol_save_holidays($data);
+
+    // Regenerate future sessions without attendance records.
+    $manager = new \mod_attendancecontrol\local\session_manager($data);
+    $manager->regenerate_future_sessions();
+
+    return true;
+}
+
+/**
+ * Deletes an instance of attendancecontrol and all associated data.
+ *
+ * @param  int $id  Module instance ID.
+ * @return bool
+ */
+function attendancecontrol_delete_instance(int $id): bool {
+    global $DB;
+
+    if (!$DB->get_record('attendancecontrol', ['id' => $id])) {
+        return false;
+    }
+
+    // Delete records, sessions, schedule, holidays, then the instance.
+    $sessionids = $DB->get_fieldset_select(
+        'attendancecontrol_session',
+        'id',
+        'attendancecontrolid = :id',
+        ['id' => $id]
+    );
+
+    if ($sessionids) {
+        [$insql, $inparams] = $DB->get_in_or_equal($sessionids);
+        $DB->delete_records_select('attendancecontrol_record', "sessionid $insql", $inparams);
+    }
+
+    $DB->delete_records('attendancecontrol_session',  ['attendancecontrolid' => $id]);
+    $DB->delete_records('attendancecontrol_schedule', ['attendancecontrolid' => $id]);
+    $DB->delete_records('attendancecontrol_holiday',  ['attendancecontrolid' => $id]);
+    $DB->delete_records('attendancecontrol',          ['id'                  => $id]);
+
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Feature-support flags.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the features this module supports.
+ *
+ * @param  string $feature  FEATURE_* constant.
+ * @return bool|null        True/false or null when unknown.
+ */
+function attendancecontrol_supports(string $feature): ?bool {
+    switch ($feature) {
+        case FEATURE_GROUPS:
+            return true;
+        case FEATURE_GROUPINGS:
+            return true;
+        case FEATURE_MOD_INTRO:
+            return true;
+        case FEATURE_BACKUP_MOODLE2:
+            return true;
+        case FEATURE_SHOW_DESCRIPTION:
+            return true;
+        case FEATURE_MOD_PURPOSE:
+            return MOD_PURPOSE_COLLABORATION;
+        default:
+            return null;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions used internally by the callbacks above.
+// ---------------------------------------------------------------------------
+
+/**
+ * Persists schedule slots from the repeatable form element.
+ *
+ * @param stdClass $data  Form data containing schedule_day, schedule_start,
+ *                        schedule_end arrays from the repeating group.
+ */
+function attendancecontrol_save_schedule(stdClass $data): void {
+    global $DB;
+
+    if (empty($data->schedule_day)) {
+        return;
+    }
+
+    foreach ($data->schedule_day as $i => $day) {
+        if (empty($day)) {
+            continue;
+        }
+        $slot = (object) [
+            'attendancecontrolid' => $data->id,
+            'day_of_week'         => (int) $day,
+            'start_time'          => $data->schedule_start[$i],
+            'end_time'            => $data->schedule_end[$i],
+        ];
+        $DB->insert_record('attendancecontrol_schedule', $slot);
+    }
+}
+
+/**
+ * Persists holiday dates from the repeatable form element.
+ *
+ * @param stdClass $data  Form data containing holiday_date and
+ *                        holiday_description arrays.
+ */
+function attendancecontrol_save_holidays(stdClass $data): void {
+    global $DB;
+
+    if (empty($data->holiday_date)) {
+        return;
+    }
+
+    foreach ($data->holiday_date as $i => $date) {
+        if (empty($date)) {
+            continue;
+        }
+        $holiday = (object) [
+            'attendancecontrolid' => $data->id,
+            'holiday_date'        => $date,
+            'description'         => $data->holiday_description[$i] ?? '',
+        ];
+        $DB->insert_record('attendancecontrol_holiday', $holiday);
+    }
+}

--- a/mod_form.php
+++ b/mod_form.php
@@ -1,0 +1,234 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Activity instance configuration form.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/course/moodleform_mod.php');
+
+/**
+ * Form for adding/editing an attendancecontrol activity instance.
+ */
+class mod_attendancecontrol_mod_form extends moodleform_mod {
+
+    /**
+     * Defines the form fields.
+     */
+    public function definition(): void {
+        global $COURSE;
+
+        $mform = $this->_form;
+
+        // ----------------------------------------------------------------
+        // General section (name + intro provided by moodleform_mod).
+        // ----------------------------------------------------------------
+        $mform->addElement('header', 'general', get_string('general', 'form'));
+
+        $this->standard_intro_elements();
+
+        // ----------------------------------------------------------------
+        // Group selection.
+        // ----------------------------------------------------------------
+        $groups = groups_get_all_groups($COURSE->id);
+        $groupoptions = [];
+        foreach ($groups as $g) {
+            $groupoptions[$g->id] = format_string($g->name);
+        }
+
+        $mform->addElement('select', 'groupid', get_string('group', 'mod_attendancecontrol'), $groupoptions);
+        $mform->addRule('groupid', null, 'required', null, 'client');
+        $mform->addHelpButton('groupid', 'group', 'mod_attendancecontrol');
+
+        // ----------------------------------------------------------------
+        // Course date range.
+        // ----------------------------------------------------------------
+        $mform->addElement('header', 'daterangehdr', get_string('daterange', 'mod_attendancecontrol'));
+
+        $mform->addElement('date_selector', 'course_start_date', get_string('coursestartdate', 'mod_attendancecontrol'));
+        $mform->addRule('course_start_date', null, 'required', null, 'client');
+
+        $mform->addElement('date_selector', 'course_end_date', get_string('courseenddate', 'mod_attendancecontrol'));
+        $mform->addRule('course_end_date', null, 'required', null, 'client');
+
+        // ----------------------------------------------------------------
+        // Total hours.
+        // ----------------------------------------------------------------
+        $mform->addElement('text', 'total_hours', get_string('totalhours', 'mod_attendancecontrol'), ['size' => 5]);
+        $mform->setType('total_hours', PARAM_INT);
+        $mform->addRule('total_hours', null, 'required', null, 'client');
+        $mform->addRule('total_hours', null, 'numeric', null, 'client');
+        $mform->addRule('total_hours', null, 'nonzero', null, 'client');
+
+        // ----------------------------------------------------------------
+        // Weekly schedule (repeatable).
+        // ----------------------------------------------------------------
+        $mform->addElement('header', 'schedulehdr', get_string('schedule', 'mod_attendancecontrol'));
+
+        $repeatarray = [];
+        $repeatarray[] = $mform->createElement(
+            'select',
+            'schedule_day',
+            get_string('dayofweek', 'mod_attendancecontrol'),
+            attendancecontrol_get_day_options()
+        );
+        $repeatarray[] = $mform->createElement(
+            'text',
+            'schedule_start',
+            get_string('starttime', 'mod_attendancecontrol'),
+            ['placeholder' => 'HH:MM', 'size' => 6]
+        );
+        $repeatarray[] = $mform->createElement(
+            'text',
+            'schedule_end',
+            get_string('endtime', 'mod_attendancecontrol'),
+            ['placeholder' => 'HH:MM', 'size' => 6]
+        );
+
+        $repeatoptions = [];
+        $repeatoptions['schedule_start']['type'] = PARAM_TEXT;
+        $repeatoptions['schedule_end']['type']   = PARAM_TEXT;
+
+        $this->repeat_elements(
+            $repeatarray,
+            1,
+            $repeatoptions,
+            'schedule_count',
+            'schedule_add',
+            1,
+            get_string('addslot', 'mod_attendancecontrol')
+        );
+
+        // ----------------------------------------------------------------
+        // Holidays (repeatable).
+        // ----------------------------------------------------------------
+        $mform->addElement('header', 'holidayshdr', get_string('holidays', 'mod_attendancecontrol'));
+
+        $holidayrepeat = [];
+        $holidayrepeat[] = $mform->createElement('date_selector', 'holiday_date', get_string('holidaydate', 'mod_attendancecontrol'));
+        $holidayrepeat[] = $mform->createElement(
+            'text',
+            'holiday_description',
+            get_string('holidaydescription', 'mod_attendancecontrol'),
+            ['size' => 30]
+        );
+
+        $holidayoptions = [];
+        $holidayoptions['holiday_description']['type'] = PARAM_TEXT;
+
+        $this->repeat_elements(
+            $holidayrepeat,
+            0,
+            $holidayoptions,
+            'holiday_count',
+            'holiday_add',
+            1,
+            get_string('addholiday', 'mod_attendancecontrol')
+        );
+
+        // ----------------------------------------------------------------
+        // Penalty configuration.
+        // ----------------------------------------------------------------
+        $mform->addElement('header', 'penaltyhdr', get_string('penaltyconfig', 'mod_attendancecontrol'));
+
+        $mform->addElement(
+            'text',
+            'max_unjustified_absence_pct',
+            get_string('maxunjustifiedpct', 'mod_attendancecontrol'),
+            ['size' => 5]
+        );
+        $mform->setType('max_unjustified_absence_pct', PARAM_FLOAT);
+        $mform->setDefault('max_unjustified_absence_pct', 15.00);
+        $mform->addRule('max_unjustified_absence_pct', null, 'required', null, 'client');
+        $mform->addHelpButton('max_unjustified_absence_pct', 'maxunjustifiedpct', 'mod_attendancecontrol');
+
+        $mform->addElement(
+            'text',
+            'delay_to_unjustified_ratio',
+            get_string('delayratio', 'mod_attendancecontrol'),
+            ['size' => 5]
+        );
+        $mform->setType('delay_to_unjustified_ratio', PARAM_FLOAT);
+        $mform->setDefault('delay_to_unjustified_ratio', 0.50);
+        $mform->addRule('delay_to_unjustified_ratio', null, 'required', null, 'client');
+        $mform->addHelpButton('delay_to_unjustified_ratio', 'delayratio', 'mod_attendancecontrol');
+
+        $mform->addElement(
+            'text',
+            'justified_to_unjustified_ratio',
+            get_string('justifiedratio', 'mod_attendancecontrol'),
+            ['size' => 5]
+        );
+        $mform->setType('justified_to_unjustified_ratio', PARAM_FLOAT);
+        $mform->setDefault('justified_to_unjustified_ratio', 0.50);
+        $mform->addRule('justified_to_unjustified_ratio', null, 'required', null, 'client');
+        $mform->addHelpButton('justified_to_unjustified_ratio', 'justifiedratio', 'mod_attendancecontrol');
+
+        // Standard grade/completion elements.
+        $this->standard_coursemodule_elements();
+        $this->add_action_buttons();
+    }
+
+    /**
+     * Extra server-side validation.
+     *
+     * @param  array  $data   Submitted form data.
+     * @param  array  $files  Uploaded files.
+     * @return array          Associative array of errors (fieldname => message).
+     */
+    public function validation($data, $files): array {
+        $errors = parent::validation($data, $files);
+
+        if (!empty($data['course_start_date']) && !empty($data['course_end_date'])) {
+            if ($data['course_end_date'] <= $data['course_start_date']) {
+                $errors['course_end_date'] = get_string('err_enddatebeforestart', 'mod_attendancecontrol');
+            }
+        }
+
+        if (!empty($data['total_hours']) && $data['total_hours'] <= 0) {
+            $errors['total_hours'] = get_string('err_hourspositive', 'mod_attendancecontrol');
+        }
+
+        foreach (['max_unjustified_absence_pct', 'delay_to_unjustified_ratio', 'justified_to_unjustified_ratio'] as $field) {
+            if (isset($data[$field]) && ($data[$field] < 0 || $data[$field] > 100)) {
+                $errors[$field] = get_string('err_invalidratio', 'mod_attendancecontrol');
+            }
+        }
+
+        return $errors;
+    }
+}
+
+/**
+ * Returns localized weekday options (Monday–Friday).
+ *
+ * @return array Indexed by ISO day number (1 = Monday … 5 = Friday).
+ */
+function attendancecontrol_get_day_options(): array {
+    return [
+        1 => get_string('monday',    'calendar'),
+        2 => get_string('tuesday',   'calendar'),
+        3 => get_string('wednesday', 'calendar'),
+        4 => get_string('thursday',  'calendar'),
+        5 => get_string('friday',    'calendar'),
+    ];
+}

--- a/pix/icon.svg
+++ b/pix/icon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="Control de Asistencia">
+  <!-- Clipboard body -->
+  <rect x="15" y="20" width="70" height="72" rx="6" ry="6" fill="#1177d1"/>
+  <!-- Clipboard clip -->
+  <rect x="35" y="12" width="30" height="16" rx="4" ry="4" fill="#0d5da6"/>
+  <!-- Check rows -->
+  <!-- Row 1 - check mark -->
+  <polyline points="27,45 33,52 43,38" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <line x1="50" y1="45" x2="78" y2="45" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
+  <!-- Row 2 - check mark -->
+  <polyline points="27,62 33,69 43,55" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <line x1="50" y1="62" x2="78" y2="62" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
+  <!-- Row 3 - partial (pending) -->
+  <circle cx="35" cy="79" r="5" fill="none" stroke="#ffffff" stroke-width="3"/>
+  <line x1="50" y1="79" x2="78" y2="79" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/report.php
+++ b/report.php
@@ -1,0 +1,55 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Full group attendance summary report.
+ *
+ * Shows one row per student with counts, equivalent hours and the
+ * attendance percentage. Rows below the threshold are highlighted in red.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+
+$id = required_param('id', PARAM_INT); // Course-module ID.
+
+[$course, $cm] = get_course_and_cm_from_cmid($id, 'attendancecontrol');
+
+require_login($course, true, $cm);
+
+$context  = context_module::instance($cm->id);
+$instance = $DB->get_record('attendancecontrol', ['id' => $cm->instance], '*', MUST_EXIST);
+
+require_capability('mod/attendancecontrol:viewsummary', $context);
+
+$PAGE->set_url('/mod/attendancecontrol/report.php', ['id' => $id]);
+$PAGE->set_title(get_string('reporttitle', 'mod_attendancecontrol'));
+$PAGE->set_heading(format_string($course->fullname));
+$PAGE->set_context($context);
+
+$calculator = new \mod_attendancecontrol\local\attendance_calculator($instance);
+$summary    = $calculator->get_group_summary();
+
+$renderer = $PAGE->get_renderer('mod_attendancecontrol');
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('reporttitle', 'mod_attendancecontrol'));
+echo $renderer->render_summary_table($summary, $instance, $cm);
+echo $OUTPUT->footer();

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Global plugin settings (site administration).
+ *
+ * This plugin has no site-level settings in v1; the file is kept as a
+ * placeholder to avoid Moodle install/upgrade warnings.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();

--- a/student_detail.php
+++ b/student_detail.php
@@ -1,0 +1,64 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Per-student session-by-session detail view.
+ *
+ * Accessible by teachers/managers viewing any student, and by students
+ * viewing their own data (viewownattendance capability).
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+
+$cmid   = required_param('id',     PARAM_INT); // Course-module ID.
+$userid = required_param('userid', PARAM_INT); // Target student user ID.
+
+[$course, $cm] = get_course_and_cm_from_cmid($cmid, 'attendancecontrol');
+
+require_login($course, true, $cm);
+
+$context  = context_module::instance($cm->id);
+$instance = $DB->get_record('attendancecontrol', ['id' => $cm->instance], '*', MUST_EXIST);
+
+// Students may only view their own data.
+if (!has_capability('mod/attendancecontrol:viewsummary', $context)) {
+    require_capability('mod/attendancecontrol:viewownattendance', $context);
+    if ($userid !== (int) $USER->id) {
+        throw new \moodle_exception('accessdenied', 'admin');
+    }
+}
+
+$student = core_user::get_user($userid, '*', MUST_EXIST);
+
+$PAGE->set_url('/mod/attendancecontrol/student_detail.php', ['id' => $cmid, 'userid' => $userid]);
+$PAGE->set_title(fullname($student));
+$PAGE->set_heading(format_string($course->fullname));
+$PAGE->set_context($context);
+
+$calculator = new \mod_attendancecontrol\local\attendance_calculator($instance);
+$detail     = $calculator->get_student_detail($userid);
+
+$renderer = $PAGE->get_renderer('mod_attendancecontrol');
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading(fullname($student));
+echo $renderer->render_student_detail($detail, $instance, $student);
+echo $OUTPUT->footer();

--- a/templates/session_list.mustache
+++ b/templates/session_list.mustache
@@ -1,0 +1,86 @@
+{{!
+  Template: session_list.mustache
+
+  Context:
+    cmid         - int   Course-module ID
+    url_today    - string URL to record today's attendance
+    url_report   - string URL to the full report
+    url_prevweek - string URL for previous week navigation
+    url_nextweek - string URL for next week navigation
+    week_label   - string Formatted week range label
+    sessions     - array  Session objects (see renderer.php)
+    hassessions  - bool   Whether there are sessions this week
+    str_register - string Localised button label
+    str_report   - string Localised button label
+    str_prev     - string Localised nav label
+    str_next     - string Localised nav label
+
+  @package mod_attendancecontrol
+  @copyright 2026 Kings Corner Formación Profesional
+  @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+}}
+<div class="mod-attendancecontrol-view" data-region="attendancecontrol-view">
+
+  {{! Action buttons }}
+  <div class="d-flex gap-2 mb-4">
+    <a href="{{url_today}}" class="btn btn-primary">
+      {{str_register}}
+    </a>
+    <a href="{{url_report}}" class="btn btn-secondary">
+      {{str_report}}
+    </a>
+  </div>
+
+  {{! Week navigation }}
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <a href="{{url_prevweek}}" class="btn btn-outline-secondary btn-sm">
+      {{str_prev}}
+    </a>
+    <span class="fw-semibold">{{week_label}}</span>
+    <a href="{{url_nextweek}}" class="btn btn-outline-secondary btn-sm">
+      {{str_next}}
+    </a>
+  </div>
+
+  {{! Session table }}
+  {{#hassessions}}
+  <div class="table-responsive">
+    <table class="table table-hover table-sm generaltable" data-region="session-table">
+      <thead class="table-light">
+        <tr>
+          <th scope="col">{{#str}} sessiondate, mod_attendancecontrol {{/str}}</th>
+          <th scope="col">{{#str}} sessionschedule, mod_attendancecontrol {{/str}}</th>
+          <th scope="col">{{#str}} sessionstatus, mod_attendancecontrol {{/str}}</th>
+          <th scope="col"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#sessions}}
+        <tr class="{{#is_today}}table-info fw-bold{{/is_today}}">
+          <td>{{date_label}}</td>
+          <td>{{schedule}}</td>
+          <td>
+            {{#is_recorded}}
+              <span class="badge bg-success">{{status_label}}</span>
+            {{/is_recorded}}
+            {{^is_recorded}}
+              <span class="badge bg-warning text-dark">{{status_label}}</span>
+            {{/is_recorded}}
+          </td>
+          <td>
+            <a href="{{url_record}}" class="btn btn-sm btn-outline-primary">
+              {{#str}} recordattendance, mod_attendancecontrol {{/str}}
+            </a>
+          </td>
+        </tr>
+        {{/sessions}}
+      </tbody>
+    </table>
+  </div>
+  {{/hassessions}}
+
+  {{^hassessions}}
+  <p class="text-muted">{{#str}} nosessionsthisweek, mod_attendancecontrol {{/str}}</p>
+  {{/hassessions}}
+
+</div>

--- a/templates/student_detail.mustache
+++ b/templates/student_detail.mustache
@@ -1,0 +1,62 @@
+{{!
+  Template: student_detail.mustache
+
+  Context:
+    student_name     - string  Full name
+    pct              - string  Formatted attendance percentage
+    below_threshold  - bool    True if below the alert threshold
+    rows             - array   Session detail rows (see renderer.php)
+
+  @package mod_attendancecontrol
+  @copyright 2026 Kings Corner Formación Profesional
+  @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+}}
+<div class="mod-attendancecontrol-detail" data-region="student-detail">
+
+  {{! Student attendance summary header }}
+  <div class="card mb-4 {{#below_threshold}}border-danger{{/below_threshold}}">
+    <div class="card-body">
+      <h5 class="card-title">{{student_name}}</h5>
+      <p class="card-text fs-4 fw-bold {{#below_threshold}}text-danger{{/below_threshold}}">
+        {{#str}} attendancepct, mod_attendancecontrol {{/str}}: {{pct}}%
+      </p>
+      {{#below_threshold}}
+      <div class="alert alert-danger mb-0" role="alert">
+        {{#str}} alertthresholdreached, mod_attendancecontrol {{/str}}
+      </div>
+      {{/below_threshold}}
+    </div>
+  </div>
+
+  {{! Per-session breakdown table }}
+  <h5>{{#str}} sessionbreakdown, mod_attendancecontrol {{/str}}</h5>
+  <div class="table-responsive">
+    <table class="table table-hover table-sm generaltable" data-region="session-detail-table">
+      <thead class="table-light">
+        <tr>
+          <th scope="col">{{#str}} sessiondate, mod_attendancecontrol {{/str}}</th>
+          <th scope="col">{{#str}} sessionschedule, mod_attendancecontrol {{/str}}</th>
+          <th scope="col" class="text-center">{{#str}} totalhours, mod_attendancecontrol {{/str}}</th>
+          <th scope="col">{{#str}} sessionstatus, mod_attendancecontrol {{/str}}</th>
+          <th scope="col">{{#str}} remarks, mod_attendancecontrol {{/str}}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#rows}}
+        <tr class="attendancecontrol-status-{{status_code}}">
+          <td>{{date}}</td>
+          <td>{{schedule}}</td>
+          <td class="text-center">{{duration}}</td>
+          <td>
+            <span class="badge attendancecontrol-badge-{{status_code}}">
+              {{status_label}}
+            </span>
+          </td>
+          <td class="text-muted small">{{remarks}}</td>
+        </tr>
+        {{/rows}}
+      </tbody>
+    </table>
+  </div>
+
+</div>

--- a/templates/student_summary.mustache
+++ b/templates/student_summary.mustache
@@ -1,0 +1,62 @@
+{{!
+  Template: student_summary.mustache
+
+  Shown to students on view.php when they have viewownattendance capability.
+
+  Context:
+    presences        - int
+    lates            - int
+    justified        - int
+    unjustified      - int
+    pct              - string  Formatted attendance percentage
+    below_threshold  - bool
+    url_breakdown    - string  URL to student_detail.php
+    str_breakdown    - string  Localised link label
+
+  @package mod_attendancecontrol
+  @copyright 2026 Kings Corner Formación Profesional
+  @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+}}
+<div class="mod-attendancecontrol-student-summary" data-region="student-summary">
+
+  <div class="card {{#below_threshold}}border-danger{{/below_threshold}}">
+    <div class="card-header fw-semibold">
+      {{#str}} myattendance, mod_attendancecontrol {{/str}}
+    </div>
+    <div class="card-body">
+      <div class="row row-cols-2 row-cols-md-4 g-3 mb-3">
+        <div class="col">
+          <div class="text-muted small">{{#str}} presences, mod_attendancecontrol {{/str}}</div>
+          <div class="fs-5 fw-bold text-success">{{presences}}</div>
+        </div>
+        <div class="col">
+          <div class="text-muted small">{{#str}} lates, mod_attendancecontrol {{/str}}</div>
+          <div class="fs-5 fw-bold text-warning">{{lates}}</div>
+        </div>
+        <div class="col">
+          <div class="text-muted small">{{#str}} justifiedabsences, mod_attendancecontrol {{/str}}</div>
+          <div class="fs-5 fw-bold text-info">{{justified}}</div>
+        </div>
+        <div class="col">
+          <div class="text-muted small">{{#str}} unjustifiedabsences, mod_attendancecontrol {{/str}}</div>
+          <div class="fs-5 fw-bold text-danger">{{unjustified}}</div>
+        </div>
+      </div>
+
+      <p class="fs-3 fw-bold {{#below_threshold}}text-danger{{/below_threshold}}">
+        {{pct}}%
+      </p>
+
+      {{#below_threshold}}
+      <div class="alert alert-danger" role="alert">
+        {{#str}} alertthresholdreached, mod_attendancecontrol {{/str}}
+      </div>
+      {{/below_threshold}}
+
+      <a href="{{url_breakdown}}" class="btn btn-outline-primary">
+        {{str_breakdown}}
+      </a>
+    </div>
+  </div>
+
+</div>

--- a/templates/summary_table.mustache
+++ b/templates/summary_table.mustache
@@ -1,0 +1,60 @@
+{{!
+  Template: summary_table.mustache
+
+  Context:
+    rows              - array  Student summary rows (see renderer.php)
+    url_export        - string Excel export URL
+    threshold_notice  - string Formatted threshold notice
+    str_export        - string Localised export button label
+
+  @package mod_attendancecontrol
+  @copyright 2026 Kings Corner Formación Profesional
+  @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+}}
+<div class="mod-attendancecontrol-report" data-region="attendancecontrol-report">
+
+  {{! Export button }}
+  <div class="d-flex justify-content-end mb-3">
+    <a href="{{url_export}}" class="btn btn-success">
+      {{str_export}}
+    </a>
+  </div>
+
+  {{! Threshold notice }}
+  <p class="text-muted small mb-3">{{threshold_notice}}</p>
+
+  {{! Summary table }}
+  <div class="table-responsive">
+    <table class="table table-hover table-sm generaltable" data-region="summary-table">
+      <thead class="table-light">
+        <tr>
+          <th scope="col">{{#str}} studentname, mod_attendancecontrol {{/str}}</th>
+          <th scope="col" class="text-center">{{#str}} presences, mod_attendancecontrol {{/str}}</th>
+          <th scope="col" class="text-center">{{#str}} lates, mod_attendancecontrol {{/str}}</th>
+          <th scope="col" class="text-center">{{#str}} justifiedabsences, mod_attendancecontrol {{/str}}</th>
+          <th scope="col" class="text-center">{{#str}} unjustifiedabsences, mod_attendancecontrol {{/str}}</th>
+          <th scope="col" class="text-center">{{#str}} equivalenthours, mod_attendancecontrol {{/str}}</th>
+          <th scope="col" class="text-center">{{#str}} attendancepct, mod_attendancecontrol {{/str}}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#rows}}
+        <tr class="{{#below_threshold}}table-danger{{/below_threshold}}">
+          <td>
+            <a href="{{url_detail}}">{{student_name}}</a>
+          </td>
+          <td class="text-center">{{presences}}</td>
+          <td class="text-center">{{lates}}</td>
+          <td class="text-center">{{justified}}</td>
+          <td class="text-center">{{unjustified}}</td>
+          <td class="text-center">{{equiv_hours}}</td>
+          <td class="text-center fw-semibold {{#below_threshold}}text-danger{{/below_threshold}}">
+            {{pct}}%
+          </td>
+        </tr>
+        {{/rows}}
+      </tbody>
+    </table>
+  </div>
+
+</div>

--- a/tests/attendance_calculator_test.php
+++ b/tests/attendance_calculator_test.php
@@ -1,0 +1,184 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * PHPUnit tests for attendance_calculator.
+ *
+ * @package    mod_attendancecontrol
+ * @category   test
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol;
+
+use mod_attendancecontrol\local\attendance_calculator;
+
+/**
+ * Unit tests for \mod_attendancecontrol\local\attendance_calculator.
+ *
+ * @coversDefaultClass \mod_attendancecontrol\local\attendance_calculator
+ */
+class attendance_calculator_test extends \advanced_testcase {
+
+    // -----------------------------------------------------------------------
+    // Helpers.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Builds a minimal instance stdClass for the calculator.
+     *
+     * @param  int   $total     Total hours.
+     * @param  float $delayr    Delay ratio.
+     * @param  float $justr     Justified ratio.
+     * @param  float $maxpct    Max unjustified %.
+     * @return \stdClass
+     */
+    private function make_instance(
+        int $total = 100,
+        float $delayr = 0.50,
+        float $justr  = 0.50,
+        float $maxpct = 15.00
+    ): \stdClass {
+        return (object) [
+            'id'                              => 1,
+            'total_hours'                     => $total,
+            'delay_to_unjustified_ratio'      => $delayr,
+            'justified_to_unjustified_ratio'  => $justr,
+            'max_unjustified_absence_pct'     => $maxpct,
+        ];
+    }
+
+    // -----------------------------------------------------------------------
+    // get_threshold.
+    // -----------------------------------------------------------------------
+
+    /**
+     * @covers ::get_threshold
+     */
+    public function test_get_threshold(): void {
+        $calc = new attendance_calculator($this->make_instance(100, 0.5, 0.5, 15.0));
+        $this->assertEqualsWithDelta(85.0, $calc->get_threshold(), 0.001);
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_equivalent_absence_hours & compute_attendance_pct (via DB).
+    // -----------------------------------------------------------------------
+
+    /**
+     * Verifies the PRD example calculation:
+     *   2 lates (1h each)  → 2 × 1 × 0.5 = 1h equiv
+     *   1 justified (4h)   → 1 × 4 × 0.5 = 2h equiv
+     *   1 unjustified (2h) → 1 × 2 × 1.0 = 2h equiv
+     *   Total equiv: 5h → 95% attendance.
+     *
+     * @covers ::compute_equivalent_absence_hours
+     * @covers ::compute_attendance_pct
+     */
+    public function test_prd_example_calculation(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $course   = $this->getDataGenerator()->create_course();
+        $student  = $this->getDataGenerator()->create_user();
+
+        // Build instance.
+        $instance = $this->make_instance(100, 0.5, 0.5, 15.0);
+        $instance->course       = $course->id;
+        $instance->name         = 'PRD test';
+        $instance->intro        = '';
+        $instance->introformat  = FORMAT_HTML;
+        $instance->groupid      = 0;
+        $instance->course_start_date           = mktime(0, 0, 0, 9, 1, 2025);
+        $instance->course_end_date             = mktime(0, 0, 0, 6, 30, 2026);
+        $instance->timecreated  = time();
+        $instance->timemodified = time();
+
+        $instance->id = $DB->insert_record('attendancecontrol', $instance);
+
+        // Create sessions.
+        $now = time();
+        $s1id = $DB->insert_record('attendancecontrol_session', (object) [
+            'attendancecontrolid' => $instance->id,
+            'session_date'        => mktime(0, 0, 0, 9, 15, 2025),
+            'start_time'          => '09:00',
+            'end_time'            => '10:00',
+            'duration_hours'      => 1, // 2 lates in 1h sessions.
+            'status'              => 1,
+            'timecreated'         => $now,
+            'timemodified'        => $now,
+        ]);
+        $s2id = $DB->insert_record('attendancecontrol_session', (object) [
+            'attendancecontrolid' => $instance->id,
+            'session_date'        => mktime(0, 0, 0, 9, 16, 2025),
+            'start_time'          => '09:00',
+            'end_time'            => '10:00',
+            'duration_hours'      => 1, // Second late.
+            'status'              => 1,
+            'timecreated'         => $now,
+            'timemodified'        => $now,
+        ]);
+        $s3id = $DB->insert_record('attendancecontrol_session', (object) [
+            'attendancecontrolid' => $instance->id,
+            'session_date'        => mktime(0, 0, 0, 9, 17, 2025),
+            'start_time'          => '09:00',
+            'end_time'            => '13:00',
+            'duration_hours'      => 4, // Justified absence.
+            'status'              => 1,
+            'timecreated'         => $now,
+            'timemodified'        => $now,
+        ]);
+        $s4id = $DB->insert_record('attendancecontrol_session', (object) [
+            'attendancecontrolid' => $instance->id,
+            'session_date'        => mktime(0, 0, 0, 9, 18, 2025),
+            'start_time'          => '09:00',
+            'end_time'            => '11:00',
+            'duration_hours'      => 2, // Unjustified absence.
+            'status'              => 1,
+            'timecreated'         => $now,
+            'timemodified'        => $now,
+        ]);
+
+        // Create attendance records.
+        foreach ([
+            [$s1id, 2], // late.
+            [$s2id, 2], // late.
+            [$s3id, 3], // justified.
+            [$s4id, 4], // unjustified.
+        ] as [$sid, $status]) {
+            $DB->insert_record('attendancecontrol_record', (object) [
+                'sessionid'    => $sid,
+                'userid'       => $student->id,
+                'status'       => $status,
+                'remarks'      => '',
+                'recorded_by'  => 2,
+                'timecreated'  => $now,
+                'timemodified' => $now,
+            ]);
+        }
+
+        $calc = new attendance_calculator($instance);
+
+        $this->assertEqualsWithDelta(5.0, $calc->compute_equivalent_absence_hours($student->id), 0.001);
+        $this->assertEqualsWithDelta(95.0, $calc->compute_attendance_pct($student->id), 0.001);
+        $this->assertFalse(
+            $calc->compute_attendance_pct($student->id) < $calc->get_threshold(),
+            '95% should be above the 85% threshold'
+        );
+    }
+}

--- a/tests/behat/mod_attendancecontrol.feature
+++ b/tests/behat/mod_attendancecontrol.feature
@@ -1,0 +1,58 @@
+@mod @mod_attendancecontrol
+Feature: Control de Asistencia – flujos principales
+  Como profesor
+  Quiero configurar y registrar asistencia
+  Para llevar un control preciso de la asistencia del alumnado
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname |
+      | FP Test  | FP001     |
+    And the following "users" exist:
+      | username  | firstname | lastname  | email                     |
+      | teacher1  | Ana       | García    | teacher1@example.com      |
+      | student1  | Carlos    | Martínez  | student1@example.com      |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | FP001  | editingteacher |
+      | student1 | FP001  | student        |
+    And the following "groups" exist:
+      | name       | course |
+      | DAM1-Alumnos | FP001 |
+    And the following "group members" exist:
+      | user     | group        |
+      | student1 | DAM1-Alumnos |
+
+  @javascript
+  Scenario: El profesor añade la actividad al curso
+    Given I log in as "teacher1"
+    And I am on "FP Test" course homepage with editing mode on
+    When I add a "Control de Asistencia" to section "1"
+    And I set the following fields to these values:
+      | Nombre de la actividad | Asistencia Programación |
+      | Grupo de alumnos       | DAM1-Alumnos            |
+      | Horas totales          | 100                     |
+    And I press "Guardar cambios y regresar al curso"
+    Then I should see "Asistencia Programación"
+
+  @javascript
+  Scenario: El alumno ve su resumen de asistencia
+    Given the following "activities" exist:
+      | activity           | course | name                    | groupid | total_hours |
+      | attendancecontrol  | FP001  | Asistencia Programación | 0       | 100         |
+    When I log in as "student1"
+    And I am on "FP Test" course homepage
+    And I follow "Asistencia Programación"
+    Then I should see "Mi asistencia"
+    And I should not see "Registrar asistencia"
+
+  @javascript
+  Scenario: El profesor registra asistencia para una sesión
+    Given the following "activities" exist:
+      | activity           | course | name                    | groupid | total_hours |
+      | attendancecontrol  | FP001  | Asistencia Programación | 0       | 100         |
+    When I log in as "teacher1"
+    And I am on "FP Test" course homepage
+    And I follow "Asistencia Programación"
+    Then I should see "Registrar asistencia hoy"
+    And I should see "Ver datos completos"

--- a/tests/session_manager_test.php
+++ b/tests/session_manager_test.php
@@ -1,0 +1,175 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * PHPUnit tests for session_manager.
+ *
+ * @package    mod_attendancecontrol
+ * @category   test
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_attendancecontrol;
+
+use mod_attendancecontrol\local\session_manager;
+
+/**
+ * Unit tests for \mod_attendancecontrol\local\session_manager.
+ *
+ * @coversDefaultClass \mod_attendancecontrol\local\session_manager
+ */
+class session_manager_test extends \advanced_testcase {
+
+    // -----------------------------------------------------------------------
+    // compute_duration_hours – pure function, no DB needed.
+    // -----------------------------------------------------------------------
+
+    /**
+     * @covers ::compute_duration_hours
+     * @dataProvider duration_provider
+     */
+    public function test_compute_duration_hours(string $start, string $end, int $expected): void {
+        $result = session_manager::compute_duration_hours($start, $end);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider for test_compute_duration_hours.
+     *
+     * @return array[]
+     */
+    public static function duration_provider(): array {
+        return [
+            'exactly 1 hour'         => ['09:00', '10:00', 1],
+            '55 minutes rounds to 1' => ['09:00', '09:55', 1],
+            '1 hour 40 min → 2'      => ['09:00', '10:40', 2],
+            '2 hours exactly'        => ['09:00', '11:00', 2],
+            '30 minutes → 1'         => ['14:30', '15:00', 1],
+            '2 hours 59 min → 3'     => ['09:00', '11:59', 3],
+        ];
+    }
+
+    // -----------------------------------------------------------------------
+    // generate_sessions – requires DB.
+    // -----------------------------------------------------------------------
+
+    /**
+     * @covers ::generate_sessions
+     */
+    public function test_generate_sessions_excludes_holidays(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $course = $this->getDataGenerator()->create_course();
+
+        // Create a simple instance record directly (no real Moodle install needed).
+        $instance = (object) [
+            'course'                       => $course->id,
+            'name'                         => 'Test',
+            'intro'                        => '',
+            'introformat'                  => FORMAT_HTML,
+            'groupid'                      => 0,
+            'total_hours'                  => 100,
+            'course_start_date'            => mktime(0, 0, 0, 9, 1, 2025),  // Mon 2025-09-01.
+            'course_end_date'              => mktime(0, 0, 0, 9, 7, 2025),  // Sun 2025-09-07.
+            'max_unjustified_absence_pct'  => 15.00,
+            'delay_to_unjustified_ratio'   => 0.50,
+            'justified_to_unjustified_ratio' => 0.50,
+            'timecreated'                  => time(),
+            'timemodified'                 => time(),
+        ];
+
+        $instance->id = $DB->insert_record('attendancecontrol', $instance);
+
+        // Add a Monday slot (day_of_week = 1).
+        $DB->insert_record('attendancecontrol_schedule', (object) [
+            'attendancecontrolid' => $instance->id,
+            'day_of_week'         => 1,
+            'start_time'          => '09:00',
+            'end_time'            => '11:00',
+        ]);
+
+        // Mark 2025-09-01 as a holiday.
+        $DB->insert_record('attendancecontrol_holiday', (object) [
+            'attendancecontrolid' => $instance->id,
+            'holiday_date'        => mktime(0, 0, 0, 9, 1, 2025),
+            'description'         => 'Festivo test',
+        ]);
+
+        $manager = new session_manager($instance);
+        $manager->generate_sessions();
+
+        // Week 2025-09-01..07 has one Monday (Sep 1) – but it is a holiday.
+        // The next Monday would be Sep 8, which is outside the range.
+        $count = $DB->count_records('attendancecontrol_session', ['attendancecontrolid' => $instance->id]);
+        $this->assertSame(0, $count, 'Holiday on Monday should result in zero sessions for this week.');
+    }
+
+    /**
+     * @covers ::generate_sessions
+     */
+    public function test_generate_sessions_creates_correct_count(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $course = $this->getDataGenerator()->create_course();
+
+        // Range: Mon 2025-09-01 to Fri 2025-09-05.
+        $instance = (object) [
+            'course'                          => $course->id,
+            'name'                            => 'Test2',
+            'intro'                           => '',
+            'introformat'                     => FORMAT_HTML,
+            'groupid'                         => 0,
+            'total_hours'                     => 50,
+            'course_start_date'               => mktime(0, 0, 0, 9, 1, 2025),
+            'course_end_date'                 => mktime(0, 0, 0, 9, 5, 2025),
+            'max_unjustified_absence_pct'     => 15.00,
+            'delay_to_unjustified_ratio'      => 0.50,
+            'justified_to_unjustified_ratio'  => 0.50,
+            'timecreated'                     => time(),
+            'timemodified'                    => time(),
+        ];
+
+        $instance->id = $DB->insert_record('attendancecontrol', $instance);
+
+        // Two slots: Mon + Wed.
+        $DB->insert_record('attendancecontrol_schedule', (object) [
+            'attendancecontrolid' => $instance->id,
+            'day_of_week'         => 1,
+            'start_time'          => '09:00',
+            'end_time'            => '11:00',
+        ]);
+        $DB->insert_record('attendancecontrol_schedule', (object) [
+            'attendancecontrolid' => $instance->id,
+            'day_of_week'         => 3,
+            'start_time'          => '09:00',
+            'end_time'            => '11:00',
+        ]);
+
+        $manager = new session_manager($instance);
+        $manager->generate_sessions();
+
+        // Sep 1 = Mon, Sep 3 = Wed → 2 sessions.
+        $count = $DB->count_records('attendancecontrol_session', ['attendancecontrolid' => $instance->id]);
+        $this->assertSame(2, $count);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Plugin version information.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->version   = 2026021800;        // YYYYMMDDXX.
+$plugin->requires  = 2024100700;        // Moodle 4.5 (2024100700).
+$plugin->component = 'mod_attendancecontrol';
+$plugin->release   = '1.0.0';
+$plugin->maturity  = MATURITY_ALPHA;

--- a/view.php
+++ b/view.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Main entry-point view for the attendancecontrol activity.
+ *
+ * Renders either the teacher session-list view or the student summary view
+ * depending on the current user's capabilities.
+ *
+ * @package    mod_attendancecontrol
+ * @copyright  2026 Kings Corner Formación Profesional
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+
+$id = required_param('id', PARAM_INT); // Course-module ID.
+
+[$course, $cm] = get_course_and_cm_from_cmid($id, 'attendancecontrol');
+
+require_login($course, true, $cm);
+
+$context  = context_module::instance($cm->id);
+$instance = $DB->get_record('attendancecontrol', ['id' => $cm->instance], '*', MUST_EXIST);
+
+$PAGE->set_url('/mod/attendancecontrol/view.php', ['id' => $cm->id]);
+$PAGE->set_title(format_string($instance->name));
+$PAGE->set_heading(format_string($course->fullname));
+$PAGE->set_context($context);
+
+// Trigger course-module viewed event.
+$event = \mod_attendancecontrol\event\course_module_viewed::create([
+    'objectid' => $instance->id,
+    'context'  => $context,
+]);
+$event->add_record_snapshot('course', $course);
+$event->add_record_snapshot('attendancecontrol', $instance);
+$event->trigger();
+
+// Completion tracking.
+$completion = new completion_info($course);
+$completion->set_module_viewed($cm);
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading(format_string($instance->name));
+
+$renderer = $PAGE->get_renderer('mod_attendancecontrol');
+
+if (has_capability('mod/attendancecontrol:viewsummary', $context)) {
+    // Teacher / manager / non-editing teacher view.
+    echo $renderer->render_teacher_view($instance, $cm, $context);
+} else if (has_capability('mod/attendancecontrol:viewownattendance', $context)) {
+    // Student view.
+    echo $renderer->render_student_view($instance, $cm, $context);
+} else {
+    throw new \moodle_exception('accessdenied', 'admin');
+}
+
+echo $OUTPUT->footer();


### PR DESCRIPTION
Implements the full Moodle activity-module scaffold for mod_attendancecontrol
following the first three PRD sections (vision, technical architecture, user
flows) and current 2026 Moodle best practices:

Core files
- version.php  (requires Moodle 4.5 / 2024100700, plugin v2026021800)
- lib.php      (add/update/delete instance callbacks, feature flags)
- mod_form.php (moodleform_mod with group selector, date range, repeatable
                schedule slots, holiday datepicker, penalty configuration)
- view.php / index.php / settings.php
- attendance.php / report.php / student_detail.php / export.php

Database (db/)
- install.xml   — 5 tables: attendancecontrol, _schedule, _holiday,
                  _session, _record; all keys and indexes defined
- access.php    — 6 capabilities with correct risk bitmasks and archetypes
- upgrade.php / services.php

Language (lang/es/)
- attendancecontrol.php — full Spanish string set for all UI elements,
  capabilities, events and Privacy API metadata

Business logic (classes/local/)
- session_manager.php        — generate_sessions, regenerate_future_sessions,
                               save_attendance_records, compute_duration_hours
- attendance_calculator.php  — compute_equivalent_absence_hours,
                               compute_attendance_pct, get_group_summary,
                               get_student_detail (PRD formula implemented)
- export_manager.php         — MoodleExcelWorkbook 3-sheet export

Output (classes/output/ + classes/form/)
- renderer.php          — render_teacher_view, render_summary_table,
                          render_student_detail, render_student_view
- attendance_form.php   — per-student radio+remarks form with bulk-status

Events (classes/event/)
- attendance_recorded, course_module_viewed, session_created

Privacy (classes/privacy/)
- provider.php — full GDPR provider (metadata, export, delete)

Templates (Mustache)
- session_list, summary_table, student_detail, student_summary

AMD modules (amd/src/)
- attendance_form.js    — bulk-status change + collapsible remarks
- session_navigation.js — keyboard week navigation + aria-current

Backup & restore (backup/moodle2/)
- backup_attendancecontrol_activity_task.class.php + stepslib
- restore_attendancecontrol_activity_task.class.php + stepslib

Plugin icon (pix/)
- icon.svg — clipboard with check marks, Kings Corner colour (#1177d1)

Tests
- tests/session_manager_test.php        — compute_duration_hours + generate_sessions
- tests/attendance_calculator_test.php  — PRD example calculation (95%)
- tests/behat/mod_attendancecontrol.feature — 3 acceptance scenarios

https://claude.ai/code/session_01XKrCUzsHfveUZ5u7j1nryG