### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026021800;        // YYYYMMDDXX.
+$plugin->version   = 2026021900;        // YYYYMMDDXX.
 $plugin->requires  = 2024100700;        // Moodle 4.5 (2024100700).
 $plugin->component = 'mod_attendancecontrol';
-$plugin->release   = '1.0.0';
+$plugin->release   = '1.1.0';
 $plugin->maturity  = MATURITY_ALPHA;


### PR DESCRIPTION
## Summary
Updated the plugin version and release number for the attendancecontrol module.

## Key Changes
- Incremented plugin version from 2026021800 to 2026021900
- Updated release version from 1.0.0 to 1.1.0

## Notes
This is a minor version bump, indicating new features or improvements have been added to the plugin while maintaining backward compatibility.

https://claude.ai/code/session_018qyJj5KzCCUcCerFFx3jwT