### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Force LF line endings for all text files
+* text=auto eol=lf
+
+# Explicitly enforce LF for JS/PHP/CSS/Mustache
+*.js    text eol=lf
+*.php   text eol=lf
+*.css   text eol=lf
+*.mustache text eol=lf
+*.xml   text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.txt   text eol=lf
+*.feature text eol=lf
+
+# Binary files — no conversion
+*.png   binary
+*.jpg   binary
+*.gif   binary
+*.ico   binary
+*.zip   binary


### PR DESCRIPTION
Prevents CRLF files being copied into Linux containers (e.g. Docker), which causes grunt/eslint to fail with linebreak-style errors.

https://claude.ai/code/session_019ATxc4JMApfFHCjjY6xTSe